### PR TITLE
feat: add translate for learnerVariantDashboard.aboutUs id

### DIFF
--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/ar.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/ar.json
@@ -152,5 +152,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "لم يوافق {providerName} على طلبك للحصول على رصيد الدورة التدريبية. لمزيد من المعلومات اتصل مباشرة {linkToProviderSite} .",
   "learner-dash.courseCard.banners.credit.requestCredit": "اطلب مادّة دراسية",
   "learner-dash.courseCard.banners.credit.viewCredit": "استعرض المواد الدراسية",
-  "learner-dash.courseCard.banners.credit.viewDetails": "استعرض التفاصيل"
+  "learner-dash.courseCard.banners.credit.viewDetails": "استعرض التفاصيل",
+  "learnerVariantDashboard.aboutUs": "حول EDU"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/bo.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/bo.json
@@ -142,5 +142,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName} ཡིས་ཁྱེད་ཀྱི་སློབ་ཚན་གྱི་credit ཡི་རེ་ཞུ་དེ་ངོས་ལེན་བྱས་མ་སོང་། འདིའི་སྐོར་གྱི་གནས་ཚུལ་རྒྱས་པ་དགོས་ན་ཐད་ཀར་ {linkToProviderSite} འདིར་འབྲེལ་བ་གནང་རོགས།",
   "learner-dash.courseCard.banners.credit.requestCredit": "Credit ཡི་རེ་ཞུ།",
   "learner-dash.courseCard.banners.credit.viewCredit": "Credit སྟོན།",
-  "learner-dash.courseCard.banners.credit.viewDetails": "ཞིབ་ཕྲར་གཟིགས།"
+  "learner-dash.courseCard.banners.credit.viewDetails": "ཞིབ་ཕྲར་གཟིགས།",
+  "learnerVariantDashboard.aboutUs": "EDU སྐོར་ལ་"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/da.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/da.json
@@ -152,5 +152,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName} godkendte ikke din anmodning om kursuskredit. For mere information, kontakt {linkToProviderSite} direkte.",
   "learner-dash.courseCard.banners.credit.requestCredit": "Anmod om kredit",
   "learner-dash.courseCard.banners.credit.viewCredit": "Se Rabat",
-  "learner-dash.courseCard.banners.credit.viewDetails": "Se Detaljer"
+  "learner-dash.courseCard.banners.credit.viewDetails": "Se Detaljer",
+  "learnerVariantDashboard.aboutUs": "Om EDU"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/de.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/de.json
@@ -53,5 +53,6 @@
   "RecommendationsPanel.seeAllRecommendationsButton": "See All Recommendations",
   "RecommendationsPanel.recommendationsHeading": "Recommendations for you",
   "RecommendationsPanel.popularCoursesHeading": "Popular courses",
-  "RecommendationsPanel.exploreCoursesButton": "Kursangebot erkunden"
+  "RecommendationsPanel.exploreCoursesButton": "Kursangebot erkunden",
+  "learnerVariantDashboard.aboutUs": "Über EDU"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/de_DE.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/de_DE.json
@@ -152,5 +152,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName} hat Ihren Antrag auf Kursgutschrift nicht genehmigt. Für weitere Informationen wenden Sie sich direkt an {linkToProviderSite} .",
   "learner-dash.courseCard.banners.credit.requestCredit": "Credits anfordern",
   "learner-dash.courseCard.banners.credit.viewCredit": "Credit anzeigen",
-  "learner-dash.courseCard.banners.credit.viewDetails": "Details anzeigen"
+  "learner-dash.courseCard.banners.credit.viewDetails": "Details anzeigen",
+  "learnerVariantDashboard.aboutUs": "Über EDU"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/el.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/el.json
@@ -152,5 +152,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName} δεν ενέκρινε το αίτημά σας για πίστωση μαθήματος. Για περισσότερες πληροφορίες, επικοινωνήστε απευθείας με {linkToProviderSite} .",
   "learner-dash.courseCard.banners.credit.requestCredit": "Αίτημα αναγνώρισης",
   "learner-dash.courseCard.banners.credit.viewCredit": "Προβολή αναγνώρισης",
-  "learner-dash.courseCard.banners.credit.viewDetails": "Προβολή λεπτομερειών"
+  "learner-dash.courseCard.banners.credit.viewDetails": "Προβολή λεπτομερειών",
+  "learnerVariantDashboard.aboutUs": "Σχετικά με την EDU"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/es_419.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/es_419.json
@@ -152,5 +152,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName} no aprobó su solicitud de crédito del curso. Para obtener más información, comuníquese directamente con {linkToProviderSite} .",
   "learner-dash.courseCard.banners.credit.requestCredit": "Solicitar crédito",
   "learner-dash.courseCard.banners.credit.viewCredit": "Ver crédito",
-  "learner-dash.courseCard.banners.credit.viewDetails": "Ver detalles"
+  "learner-dash.courseCard.banners.credit.viewDetails": "Ver detalles",
+  "learnerVariantDashboard.aboutUs": "Acerca de EDU"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/es_ES.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/es_ES.json
@@ -152,5 +152,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName} no aprobó su solicitud de crédito del curso. Para obtener más información, comuníquese directamente con {linkToProviderSite} .",
   "learner-dash.courseCard.banners.credit.requestCredit": "Solicitar crédito",
   "learner-dash.courseCard.banners.credit.viewCredit": "Ver crédito",
-  "learner-dash.courseCard.banners.credit.viewDetails": "Ver detalles"
+  "learner-dash.courseCard.banners.credit.viewDetails": "Ver detalles",
+  "learnerVariantDashboard.aboutUs": "Acerca de EDU"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/fa.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/fa.json
@@ -142,5 +142,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName} درخواست شما برای اعتبار دوره را تایید نکرد. برای اطلاعات بیش‌تر، مستقیماً با {linkToProviderSite} تماس بگیرید.",
   "learner-dash.courseCard.banners.credit.requestCredit": "درخواست اعتبار",
   "learner-dash.courseCard.banners.credit.viewCredit": "مشاهده اعتبار",
-  "learner-dash.courseCard.banners.credit.viewDetails": "مشاهده جزئیات"
+  "learner-dash.courseCard.banners.credit.viewDetails": "مشاهده جزئیات",
+  "learnerVariantDashboard.aboutUs": "درباره EDU"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/fr_CA.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/fr_CA.json
@@ -152,5 +152,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName} n'a pas approuvé votre demande de crédit de cours. Pour plus d'informations, contactez directement {linkToProviderSite} .",
   "learner-dash.courseCard.banners.credit.requestCredit": "Demande de crédit",
   "learner-dash.courseCard.banners.credit.viewCredit": "Voir les crédits",
-  "learner-dash.courseCard.banners.credit.viewDetails": "Voir les détails"
+  "learner-dash.courseCard.banners.credit.viewDetails": "Voir les détails",
+  "learnerVariantDashboard.aboutUs": "À propos d'EDU"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/he.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/he.json
@@ -152,5 +152,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName} לא אישר את בקשתך לזיכוי הקורס. למידע נוסף, צור קשר ישירות עם {linkToProviderSite} .",
   "learner-dash.courseCard.banners.credit.requestCredit": "בקש נקודות זכות",
   "learner-dash.courseCard.banners.credit.viewCredit": "צפה בנקודות זכות",
-  "learner-dash.courseCard.banners.credit.viewDetails": "צפה בפרטים"
+  "learner-dash.courseCard.banners.credit.viewDetails": "צפה בפרטים",
+  "learnerVariantDashboard.aboutUs": "על EDU"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/hi.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/hi.json
@@ -152,5 +152,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName} पाठ्यक्रम क्रेडिट के लिए आपके अनुरोध को स्वीकार नहीं किया। अधिक जानकारी के लिए सीधे {linkToProviderSite} संपर्क करें।",
   "learner-dash.courseCard.banners.credit.requestCredit": "क्रेडिट का अनुरोध करें",
   "learner-dash.courseCard.banners.credit.viewCredit": "क्रेडिट देखें",
-  "learner-dash.courseCard.banners.credit.viewDetails": "विवरण देखें"
+  "learner-dash.courseCard.banners.credit.viewDetails": "विवरण देखें",
+  "learnerVariantDashboard.aboutUs": "EDU के बारे में"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/id.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/id.json
@@ -152,5 +152,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName} did not approve your request for course credit. For more information, contact {linkToProviderSite} directly.",
   "learner-dash.courseCard.banners.credit.requestCredit": "Request Credit",
   "learner-dash.courseCard.banners.credit.viewCredit": "View Credit",
-  "learner-dash.courseCard.banners.credit.viewDetails": "View Details"
+  "learner-dash.courseCard.banners.credit.viewDetails": "View Details",
+  "learnerVariantDashboard.aboutUs": "About of EDU"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/it_IT.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/it_IT.json
@@ -152,5 +152,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName} non ha approvato la tua richiesta di credito del corso. Per ulteriori informazioni contattare direttamente {linkToProviderSite} .",
   "learner-dash.courseCard.banners.credit.requestCredit": "Richiedi credito ",
   "learner-dash.courseCard.banners.credit.viewCredit": "Visualizza credito ",
-  "learner-dash.courseCard.banners.credit.viewDetails": "Visualizza dettagli"
+  "learner-dash.courseCard.banners.credit.viewDetails": "Visualizza dettagli",
+  "learnerVariantDashboard.aboutUs": "Informazioni su EDU"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/lv.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/lv.json
@@ -142,5 +142,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName} neapstiprināja jūsu pieprasījumu pēc kursa kredīta. Lai iegūtu papildinformāciju, tieši sazinieties ar {linkToProviderSite} .",
   "learner-dash.courseCard.banners.credit.requestCredit": "Pieprasīt kredītu",
   "learner-dash.courseCard.banners.credit.viewCredit": "Skatīt kredītu",
-  "learner-dash.courseCard.banners.credit.viewDetails": "Skatīt detaļas"
+  "learner-dash.courseCard.banners.credit.viewDetails": "Skatīt detaļas",
+  "learnerVariantDashboard.aboutUs": "Par EDU"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/pt_BR.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/pt_BR.json
@@ -152,5 +152,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName} não aprovou sua solicitação de crédito do curso. Para mais informações, entre em contato diretamente com {linkToProviderSite} .",
   "learner-dash.courseCard.banners.credit.requestCredit": "Pedido de crédito",
   "learner-dash.courseCard.banners.credit.viewCredit": "Visualizar crédito",
-  "learner-dash.courseCard.banners.credit.viewDetails": "Visualizar detalhes"
+  "learner-dash.courseCard.banners.credit.viewDetails": "Visualizar detalhes",
+  "learnerVariantDashboard.aboutUs": "Sobre a EDU"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/pt_PT.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/pt_PT.json
@@ -142,5 +142,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName} não aprovou o seu pedido de crédito de curso. Para mais informações, contacte diretamente {linkToProviderSite}.",
   "learner-dash.courseCard.banners.credit.requestCredit": "Solicitar Crédito",
   "learner-dash.courseCard.banners.credit.viewCredit": "Ver Crédito",
-  "learner-dash.courseCard.banners.credit.viewDetails": "Ver Detalhes"
+  "learner-dash.courseCard.banners.credit.viewDetails": "Ver Detalhes",
+  "learnerVariantDashboard.aboutUs": "Sobre a EDU"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/ro.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/ro.json
@@ -142,5 +142,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName} nu a aprobat solicitarea dvs. de credit pentru curs. Pentru mai multe informații, contactați direct {linkToProviderSite} .",
   "learner-dash.courseCard.banners.credit.requestCredit": "Solicitați credit",
   "learner-dash.courseCard.banners.credit.viewCredit": "Vedeți credit",
-  "learner-dash.courseCard.banners.credit.viewDetails": "Vedeți detalii"
+  "learner-dash.courseCard.banners.credit.viewDetails": "Vedeți detalii",
+  "learnerVariantDashboard.aboutUs": "Despre EDU"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/ru.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/ru.json
@@ -152,5 +152,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName} не одобрил ваш запрос на получение кредита за курс. Для получения дополнительной информации свяжитесь напрямую с {linkToProviderSite} .",
   "learner-dash.courseCard.banners.credit.requestCredit": "Запросить зачётные единицы",
   "learner-dash.courseCard.banners.credit.viewCredit": "Посмотреть баллы",
-  "learner-dash.courseCard.banners.credit.viewDetails": "Подробнее"
+  "learner-dash.courseCard.banners.credit.viewDetails": "Подробнее",
+  "learnerVariantDashboard.aboutUs": "О EDU"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/sw.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/sw.json
@@ -152,5 +152,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName} haikuidhinisha ombi lako la mkopo wa kozi. Kwa maelezo zaidi, wasiliana na {linkToProviderSite} moja kwa moja.",
   "learner-dash.courseCard.banners.credit.requestCredit": "Omba Mkopo",
   "learner-dash.courseCard.banners.credit.viewCredit": "Tazama Mikopo",
-  "learner-dash.courseCard.banners.credit.viewDetails": "Tazama Maelezo"
+  "learner-dash.courseCard.banners.credit.viewDetails": "Tazama Maelezo",
+  "learnerVariantDashboard.aboutUs": "Kuhusu EDU"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/te.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/te.json
@@ -152,5 +152,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName} కోర్సు క్రెడిట్ కోసం మీ అభ్యర్థనను ఆమోదించలేదు. మరింత సమాచారం కోసం, నేరుగా {linkToProviderSite} ని సంప్రదించండి.",
   "learner-dash.courseCard.banners.credit.requestCredit": "క్రెడిట్ అభ్యర్థించండి",
   "learner-dash.courseCard.banners.credit.viewCredit": "క్రెడిట్‌ని వీక్షించండి",
-  "learner-dash.courseCard.banners.credit.viewDetails": "వివరాలను వీక్షించండి"
+  "learner-dash.courseCard.banners.credit.viewDetails": "వివరాలను వీక్షించండి",
+  "learnerVariantDashboard.aboutUs": "EDU గురించి"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/th.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/th.json
@@ -152,5 +152,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName} ไม่อนุมัติคำขอเครดิตหลักสูตรของคุณ สำหรับข้อมูลเพิ่มเติมติดต่อ {linkToProviderSite} โดยตรง",
   "learner-dash.courseCard.banners.credit.requestCredit": "หน่วยกิตที่ร้องขอ",
   "learner-dash.courseCard.banners.credit.viewCredit": "ดูหน่วยกิต",
-  "learner-dash.courseCard.banners.credit.viewDetails": "ดูรายละเอียด"
+  "learner-dash.courseCard.banners.credit.viewDetails": "ดูรายละเอียด",
+  "learnerVariantDashboard.aboutUs": "เกี่ยวกับ EDU"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/tr_TR.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/tr_TR.json
@@ -142,5 +142,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName} ders kredisi talebinizi onaylamadı. Daha fazla bilgi için doğrudan {linkToProviderSite} ile iletişime geçin.",
   "learner-dash.courseCard.banners.credit.requestCredit": "Kredi Talep Et",
   "learner-dash.courseCard.banners.credit.viewCredit": "Kredi Göster",
-  "learner-dash.courseCard.banners.credit.viewDetails": "Detayları Göster"
+  "learner-dash.courseCard.banners.credit.viewDetails": "Detayları Göster",
+  "learnerVariantDashboard.aboutUs": "EDU Hakkında"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/uk.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/uk.json
@@ -152,5 +152,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName} не схвалив ваш запит на кредит за курс. Щоб отримати додаткову інформацію, зверніться безпосередньо до {linkToProviderSite} .",
   "learner-dash.courseCard.banners.credit.requestCredit": "Запросити залікові одиниці",
   "learner-dash.courseCard.banners.credit.viewCredit": "Подивитися бали",
-  "learner-dash.courseCard.banners.credit.viewDetails": "Детальніше"
+  "learner-dash.courseCard.banners.credit.viewDetails": "Детальніше",
+  "learnerVariantDashboard.aboutUs": "Про EDU"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/uz.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/uz.json
@@ -142,5 +142,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName} kurs krediti so'rovingizni ma'qullamadi. Qo'shimcha ma'lumot uchun {linkToProviderSite} bilan bevosita bog'laning.",
   "learner-dash.courseCard.banners.credit.requestCredit": "Kredit so'rash",
   "learner-dash.courseCard.banners.credit.viewCredit": "Kreditni ko'rish",
-  "learner-dash.courseCard.banners.credit.viewDetails": "Tafsilotlarni ko'rish"
+  "learner-dash.courseCard.banners.credit.viewDetails": "Tafsilotlarni ko'rish",
+  "learnerVariantDashboard.aboutUs": "EDU haqida"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/vi.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/vi.json
@@ -142,5 +142,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName} đã không chấp thuận yêu cầu tín chỉ khóa học của bạn. Để biết thêm thông tin chi tiết vui lòng liên hệ trực tiếp {linkToProviderSite} .",
   "learner-dash.courseCard.banners.credit.requestCredit": "Yêu cầu tín dụng",
   "learner-dash.courseCard.banners.credit.viewCredit": "Xem tín dụng",
-  "learner-dash.courseCard.banners.credit.viewDetails": "Xem chi tiết"
+  "learner-dash.courseCard.banners.credit.viewDetails": "Xem chi tiết",
+  "learnerVariantDashboard.aboutUs": "Giới thiệu về EDU"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/zh_CN.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/zh_CN.json
@@ -152,5 +152,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName}未批准您的课程学分请求。欲了解更多信息，请直接联系{linkToProviderSite} 。",
   "learner-dash.courseCard.banners.credit.requestCredit": "申请学分",
   "learner-dash.courseCard.banners.credit.viewCredit": "查看认证",
-  "learner-dash.courseCard.banners.credit.viewDetails": "查看详情"
+  "learner-dash.courseCard.banners.credit.viewDetails": "查看详情",
+  "learnerVariantDashboard.aboutUs": "关于 EDU"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/zh_HK.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/zh_HK.json
@@ -142,5 +142,6 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName}未核准您的課程學分請求。欲了解更多信息，請直接聯繫{linkToProviderSite} 。",
   "learner-dash.courseCard.banners.credit.requestCredit": "申請學分",
   "learner-dash.courseCard.banners.credit.viewCredit": "查看學分",
-  "learner-dash.courseCard.banners.credit.viewDetails": "查看詳情"
+  "learner-dash.courseCard.banners.credit.viewDetails": "查看詳情",
+  "learnerVariantDashboard.aboutUs": "關於 EDU"
 }

--- a/translations/frontend-component-header/src/i18n/messages/ar.json
+++ b/translations/frontend-component-header/src/i18n/messages/ar.json
@@ -32,5 +32,6 @@
   "header.menu.signOut.label": "تسجيل الخروج",
   "header.user.menu.studio": "صفحة الاستوديو الرئيسية",
   "header.user.menu.maintenance": "الصيانة",
-  "header.label.courseOutline": "الرجوع إلى مخطط المساق الكلّي في الاستوديو"
+  "header.label.courseOutline": "الرجوع إلى مخطط المساق الكلّي في الاستوديو",
+  "header.links.aboutUs": "حول EDU"
 }

--- a/translations/frontend-component-header/src/i18n/messages/bo.json
+++ b/translations/frontend-component-header/src/i18n/messages/bo.json
@@ -31,5 +31,6 @@
   "header.menu.signOut.label": "ཕྱིར་ཐོན།",
   "header.user.menu.studio": "སྒྲིག་སྟེགས་གཙོ་ངོས།",
   "header.label.courseOutline": "སྒྲིག་སྟེགས་ནང་གི་སློབ་ཚན་གྱི་སྡེ་ཚན་ས་བཅད་ཀྱི་མཚམས་སུ་ཕྱིར་ལོག",
-  "header.label.search.nav": "ནང་དོན་འཚོལ་བཤེར།"
+  "header.label.search.nav": "ནང་དོན་འཚོལ་བཤེར།",
+  "header.links.aboutUs": "EDU སྐོར་ལ"
 }

--- a/translations/frontend-component-header/src/i18n/messages/da.json
+++ b/translations/frontend-component-header/src/i18n/messages/da.json
@@ -32,5 +32,6 @@
   "header.menu.signOut.label": "Log ud",
   "header.user.menu.studio": "Studio hjem",
   "header.user.menu.maintenance": "Vedligeholdelse",
-  "header.label.courseOutline": "Tilbage til kursusoversigt i Studio"
+  "header.label.courseOutline": "Tilbage til kursusoversigt i Studio",
+  "header.links.aboutUs": "Om EDU"
 }

--- a/translations/frontend-component-header/src/i18n/messages/de.json
+++ b/translations/frontend-component-header/src/i18n/messages/de.json
@@ -52,5 +52,6 @@
   "header.links.checklists": "Checklists",
   "header.user.menu.studio": "Studio Home",
   "header.user.menu.maintenance": "Maintenance",
-  "header.label.courseOutline": "Back to course outline in Studio"
+  "header.label.courseOutline": "Back to course outline in Studio",
+  "header.links.aboutUs": "Über EDU"
 }

--- a/translations/frontend-component-header/src/i18n/messages/de_DE.json
+++ b/translations/frontend-component-header/src/i18n/messages/de_DE.json
@@ -32,5 +32,6 @@
   "header.menu.signOut.label": "Ausloggen",
   "header.user.menu.studio": "Studioheim",
   "header.user.menu.maintenance": "Wartung",
-  "header.label.courseOutline": "Zurück zur Kursübersicht im Studio"
+  "header.label.courseOutline": "Zurück zur Kursübersicht im Studio",
+  "header.links.aboutUs": "Über EDU"
 }

--- a/translations/frontend-component-header/src/i18n/messages/el.json
+++ b/translations/frontend-component-header/src/i18n/messages/el.json
@@ -32,5 +32,6 @@
   "header.menu.signOut.label": "Αποσύνδεση",
   "header.user.menu.studio": "Στούντιο Σπίτι",
   "header.user.menu.maintenance": "Συντήρηση",
-  "header.label.courseOutline": "Επιστροφή στο σχεδιάγραμμα μαθημάτων στο Στούντιο"
+  "header.label.courseOutline": "Επιστροφή στο σχεδιάγραμμα μαθημάτων στο Στούντιο",
+  "header.links.aboutUs": "Σχετικά με την EDU"
 }

--- a/translations/frontend-component-header/src/i18n/messages/es_419.json
+++ b/translations/frontend-component-header/src/i18n/messages/es_419.json
@@ -1,7 +1,7 @@
 {
-  "header.links.courses": "Cursos",
+  "header.links.courses": "Mis cursos",
   "header.links.programs": "Programas",
-  "header.links.content.search": "Encontrar nuevo",
+  "header.links.content.search": "Catálogo",
   "header.links.schools": "Escuelas y Socios",
   "header.user.menu.dashboard": "Panel de Control",
   "header.user.menu.profile": "Perfil",
@@ -31,5 +31,6 @@
   "header.menu.signOut.label": "Cerrar sesión",
   "header.user.menu.studio": "Inicio Studio",
   "header.label.courseOutline": "Volver al esquema del curso en Studio",
-  "header.label.search.nav": "Buscar contenido"
+  "header.label.search.nav": "Buscar contenido",
+  "header.links.aboutUs": "Acerca de EDU"
 }

--- a/translations/frontend-component-header/src/i18n/messages/es_ES.json
+++ b/translations/frontend-component-header/src/i18n/messages/es_ES.json
@@ -1,7 +1,7 @@
 {
-  "header.links.courses": "Cursos",
+  "header.links.courses": "Mis cursos",
   "header.links.programs": "Programas",
-  "header.links.content.search": "Nuevos cursos",
+  "header.links.content.search": "Catálogo",
   "header.links.schools": "Escuelas y Socios",
   "header.user.menu.dashboard": "Mis cursos",
   "header.user.menu.profile": "Perfil",
@@ -32,5 +32,6 @@
   "header.menu.signOut.label": "Cerrar sesión",
   "header.user.menu.studio": "Inicio Studio",
   "header.user.menu.maintenance": "Mantenimiento ",
-  "header.label.courseOutline": "Volver al esquema del curso en Studio"
+  "header.label.courseOutline": "Volver al esquema del curso en Studio",
+  "header.links.aboutUs": "Acerca de EDU"
 }

--- a/translations/frontend-component-header/src/i18n/messages/fa.json
+++ b/translations/frontend-component-header/src/i18n/messages/fa.json
@@ -31,5 +31,6 @@
   "header.menu.signOut.label": "خروج",
   "header.user.menu.studio": "خانۀ استودیو",
   "header.label.courseOutline": "بازگشت به طرح کلی درس در استودیو",
-  "header.label.search.nav": "جستجوی محتوا"
+  "header.label.search.nav": "جستجوی محتوا",
+  "header.links.aboutUs": "درباره EDU"
 }

--- a/translations/frontend-component-header/src/i18n/messages/fr_CA.json
+++ b/translations/frontend-component-header/src/i18n/messages/fr_CA.json
@@ -31,5 +31,6 @@
   "header.menu.signOut.label": "Se déconnecter",
   "header.user.menu.studio": "Accueil Studio",
   "header.label.courseOutline": "Retour au plan de cours dans Studio",
-  "header.label.search.nav": "Rechercher du contenu"
+  "header.label.search.nav": "Rechercher du contenu",
+  "header.links.aboutUs": "À propos d'EDU"
 }

--- a/translations/frontend-component-header/src/i18n/messages/he.json
+++ b/translations/frontend-component-header/src/i18n/messages/he.json
@@ -32,5 +32,6 @@
   "header.menu.signOut.label": "יציאה",
   "header.user.menu.studio": "הבית של הסטודיו",
   "header.user.menu.maintenance": "תחזוקה",
-  "header.label.courseOutline": "חזרה למתווה הקורס בסטודיו"
+  "header.label.courseOutline": "חזרה למתווה הקורס בסטודיו",
+  "header.links.aboutUs": "על EDU"
 }

--- a/translations/frontend-component-header/src/i18n/messages/hi.json
+++ b/translations/frontend-component-header/src/i18n/messages/hi.json
@@ -31,5 +31,6 @@
   "header.menu.signOut.label": "साइन आउट करें",
   "header.user.menu.studio": "स्टूडियो होम",
   "header.label.courseOutline": "स्टूडियो में पाठ्यक्रम की रूपरेखा पर वापस जाएँ",
-  "header.label.search.nav": "खोज सामग्री"
+  "header.label.search.nav": "खोज सामग्री",
+  "header.links.aboutUs": "EDU के बारे में"
 }

--- a/translations/frontend-component-header/src/i18n/messages/id.json
+++ b/translations/frontend-component-header/src/i18n/messages/id.json
@@ -32,5 +32,6 @@
   "header.menu.signOut.label": "Sign Out",
   "header.user.menu.studio": "Studio Home",
   "header.user.menu.maintenance": "Maintenance",
-  "header.label.courseOutline": "Back to course outline in Studio"
+  "header.label.courseOutline": "Back to course outline in Studio",
+  "header.links.aboutUs": "About of EDU"
 }

--- a/translations/frontend-component-header/src/i18n/messages/it_IT.json
+++ b/translations/frontend-component-header/src/i18n/messages/it_IT.json
@@ -32,5 +32,6 @@
   "header.menu.signOut.label": "Esci",
   "header.user.menu.studio": "Home di Studio",
   "header.user.menu.maintenance": "Manutenzione",
-  "header.label.courseOutline": "Torna alla struttura del corso in Studio"
+  "header.label.courseOutline": "Torna alla struttura del corso in Studio",
+  "header.links.aboutUs": "Informazioni su EDU"
 }

--- a/translations/frontend-component-header/src/i18n/messages/lv.json
+++ b/translations/frontend-component-header/src/i18n/messages/lv.json
@@ -31,5 +31,6 @@
   "header.menu.signOut.label": "Izrakstīties",
   "header.user.menu.studio": "Studio mājas lapa",
   "header.label.courseOutline": "Atgriezties uz kursa izklāstu programmā Studio",
-  "header.label.search.nav": "Meklēt saturu"
+  "header.label.search.nav": "Meklēt saturu",
+  "header.links.aboutUs": "Par EDU"
 }

--- a/translations/frontend-component-header/src/i18n/messages/pt_BR.json
+++ b/translations/frontend-component-header/src/i18n/messages/pt_BR.json
@@ -32,5 +32,6 @@
   "header.menu.signOut.label": "Sair",
   "header.user.menu.studio": "Estúdio em casa",
   "header.user.menu.maintenance": "Manutenção",
-  "header.label.courseOutline": "Visualizar resumo do curso no Studio"
+  "header.label.courseOutline": "Visualizar resumo do curso no Studio",
+  "header.links.aboutUs": "Sobre a EDU"
 }

--- a/translations/frontend-component-header/src/i18n/messages/pt_PT.json
+++ b/translations/frontend-component-header/src/i18n/messages/pt_PT.json
@@ -31,5 +31,6 @@
   "header.menu.signOut.label": "Terminar Sessão",
   "header.user.menu.studio": "Início do Studio ",
   "header.label.courseOutline": "Voltar ao resumo do curso no Studio",
-  "header.label.search.nav": "Pesquisar conteúdo"
+  "header.label.search.nav": "Pesquisar conteúdo",
+  "header.links.aboutUs": "Sobre a EDU"
 }

--- a/translations/frontend-component-header/src/i18n/messages/ru.json
+++ b/translations/frontend-component-header/src/i18n/messages/ru.json
@@ -32,5 +32,6 @@
   "header.menu.signOut.label": "Выйти",
   "header.user.menu.studio": "Studio Дом",
   "header.user.menu.maintenance": "Техническое обслуживание",
-  "header.label.courseOutline": "Вернуться к плану курса в Студии"
+  "header.label.courseOutline": "Вернуться к плану курса в Студии",
+  "header.links.aboutUs": "О EDU"
 }

--- a/translations/frontend-component-header/src/i18n/messages/sw.json
+++ b/translations/frontend-component-header/src/i18n/messages/sw.json
@@ -32,5 +32,6 @@
   "header.menu.signOut.label": "Toka",
   "header.user.menu.studio": "Nyumbani kwa Studio",
   "header.user.menu.maintenance": "Matengenezo",
-  "header.label.courseOutline": "Rudi kwenye muhtasari wa kozi katika Studio"
+  "header.label.courseOutline": "Rudi kwenye muhtasari wa kozi katika Studio",
+  "header.links.aboutUs": "Kuhusu EDU"
 }

--- a/translations/frontend-component-header/src/i18n/messages/te.json
+++ b/translations/frontend-component-header/src/i18n/messages/te.json
@@ -32,5 +32,6 @@
   "header.menu.signOut.label": "సైన్ అవుట్ చేయండి",
   "header.user.menu.studio": "స్టూడియో హోమ్",
   "header.user.menu.maintenance": "నిర్వహణ",
-  "header.label.courseOutline": "స్టూడియోలోని కోర్సు అవుట్‌లైన్‌కి తిరిగి వెళ్ళు"
+  "header.label.courseOutline": "స్టూడియోలోని కోర్సు అవుట్‌లైన్‌కి తిరిగి వెళ్ళు",
+  "header.links.aboutUs": "EDU గురించి"
 }

--- a/translations/frontend-component-header/src/i18n/messages/th.json
+++ b/translations/frontend-component-header/src/i18n/messages/th.json
@@ -32,5 +32,6 @@
   "header.menu.signOut.label": "Sign Out",
   "header.user.menu.studio": "สตูดิโอโฮม",
   "header.user.menu.maintenance": "บำรุงรักษา",
-  "header.label.courseOutline": "กลับไปที่โครงร่างหลักสูตรใน Studio"
+  "header.label.courseOutline": "กลับไปที่โครงร่างหลักสูตรใน Studio",
+  "header.links.aboutUs": "เกี่ยวกับ EDU"
 }

--- a/translations/frontend-component-header/src/i18n/messages/tr_TR.json
+++ b/translations/frontend-component-header/src/i18n/messages/tr_TR.json
@@ -32,5 +32,6 @@
   "header.menu.signOut.label": "Çıkış Yap",
   "header.user.menu.studio": "Studio Anasayfa",
   "header.user.menu.maintenance": "Bakım",
-  "header.label.courseOutline": "Studio'da ders anahattına geri dön"
+  "header.label.courseOutline": "Studio'da ders anahattına geri dön",
+  "header.links.aboutUs": "EDU Hakkında"
 }

--- a/translations/frontend-component-header/src/i18n/messages/uk.json
+++ b/translations/frontend-component-header/src/i18n/messages/uk.json
@@ -32,5 +32,6 @@
   "header.menu.signOut.label": "Вийти",
   "header.user.menu.studio": "Головна сторінка в Студії",
   "header.user.menu.maintenance": "Технічні робити",
-  "header.label.courseOutline": "Повернутися до плану курсу в Studio"
+  "header.label.courseOutline": "Повернутися до плану курсу в Studio",
+  "header.links.aboutUs": "Про EDU"
 }

--- a/translations/frontend-component-header/src/i18n/messages/uz.json
+++ b/translations/frontend-component-header/src/i18n/messages/uz.json
@@ -31,5 +31,6 @@
   "header.menu.signOut.label": "Tizimdan chiqish",
   "header.user.menu.studio": "Studio uyi",
   "header.label.courseOutline": "Studiyadagi kurs rejasiga qaytish",
-  "header.label.search.nav": "Kontentni qidirish"
+  "header.label.search.nav": "Kontentni qidirish",
+  "header.links.aboutUs": "EDU haqida"
 }

--- a/translations/frontend-component-header/src/i18n/messages/vi.json
+++ b/translations/frontend-component-header/src/i18n/messages/vi.json
@@ -31,5 +31,6 @@
   "header.menu.signOut.label": "Đăng xuất",
   "header.user.menu.studio": "Trang chủ Studio",
   "header.label.courseOutline": "Quay lại đề cương khóa học trong Studio",
-  "header.label.search.nav": "Tìm kiếm nội dung"
+  "header.label.search.nav": "Tìm kiếm nội dung",
+  "header.links.aboutUs": "Giới thiệu về EDU"
 }

--- a/translations/frontend-component-header/src/i18n/messages/zh_CN.json
+++ b/translations/frontend-component-header/src/i18n/messages/zh_CN.json
@@ -32,5 +32,6 @@
   "header.menu.signOut.label": "注销",
   "header.user.menu.studio": "工作室主页",
   "header.user.menu.maintenance": "维护",
-  "header.label.courseOutline": "返回 Studio 中的课程大纲"
+  "header.label.courseOutline": "返回 Studio 中的课程大纲",
+  "header.links.aboutUs": "关于 EDU"
 }

--- a/translations/frontend-component-header/src/i18n/messages/zh_HK.json
+++ b/translations/frontend-component-header/src/i18n/messages/zh_HK.json
@@ -31,5 +31,6 @@
   "header.menu.signOut.label": "登出",
   "header.user.menu.studio": "工作室主頁",
   "header.label.courseOutline": "返回工作室中的課程大綱",
-  "header.label.search.nav": "搜尋內容"
+  "header.label.search.nav": "搜尋內容",
+  "header.links.aboutUs": "關於 EDU"
 }


### PR DESCRIPTION
This PR introduces updated translation files for the UTEC-specific variant of the Open edX platform, addressing key localization issues in two frontend components.

## ✅ Main Changes
Updated Translations for:

- frontend-app-learner-dashboard
- frontend-component-header

New Key Added:

- `learnerVariantDashboard.aboutUs` translation added across multiple locales.

Targeted Fixes for UTEC:

- Replaced "Courses" with "Mis cursos"
- Replaced "Discover New" with "Catálogo"

These updates resolve the issues UTEC was experiencing with incorrect default text values, which were a matter of missing or incomplete translations.