### PR TITLE
feat: add myLearning translation

### DIFF
--- a/translations/edx-platform/conf/locale/es_419/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/es_419/LC_MESSAGES/django.po
@@ -27549,3 +27549,7 @@ msgstr "Accesibilidad"
 #: lms/templates/footer.html:225
 msgid "Support and Help"
 msgstr "Soporte y Ayuda"
+
+#: lms/templates/header/header.html:140
+msgid "My Learning"
+msgstr "Mi aprendizaje"

--- a/translations/edx-platform/conf/locale/es_ES/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/es_ES/LC_MESSAGES/django.po
@@ -26097,3 +26097,7 @@ msgstr "Accesibilidad"
 #: lms/templates/footer.html:225
 msgid "Support and Help"
 msgstr "Soporte y Ayuda"
+
+#: lms/templates/header/header.html:140
+msgid "My Learning"
+msgstr "Mi aprendizaje"

--- a/translations/frontend-app-account/src/i18n/messages/af_ZA.json
+++ b/translations/frontend-app-account/src/i18n/messages/af_ZA.json
@@ -336,5 +336,6 @@
   "soa_footer_main.cookies": "Koekies",
   "soa_footer_main.accessibility": "Toeganklikheid",
   "soa_footer_main.support": "Ondersteuning en Hulp",
-  "soa_footer_main.allRightReserved": "Alle regte voorbehou"
+  "soa_footer_main.allRightReserved": "Alle regte voorbehou",
+  "header.menu.soa.myLearning.label": "My leer"
 }

--- a/translations/frontend-app-account/src/i18n/messages/ar.json
+++ b/translations/frontend-app-account/src/i18n/messages/ar.json
@@ -336,5 +336,6 @@
   "soa_footer_main.cookies": "ملفات تعريف الارتباط",
   "soa_footer_main.accessibility": "إمكانية الوصول",
   "soa_footer_main.support": "الدعم والمساعدة",
-  "soa_footer_main.allRightReserved": "جميع الحقوق محفوظة"
+  "soa_footer_main.allRightReserved": "جميع الحقوق محفوظة",
+  "header.menu.soa.myLearning.label": "تعلّمي"
 }

--- a/translations/frontend-app-account/src/i18n/messages/az.json
+++ b/translations/frontend-app-account/src/i18n/messages/az.json
@@ -329,5 +329,6 @@
   "id.verification.requirements.card.device.text": "Kamera olan bir cihaz lazımdır. Brauzerinizdən kameranıza giriş üçün sorğu alsanız, {allow} düyməsini basdığınızdan əmin olun.",
   "id.verification.account.name.summary.alert": "Hesab parametrləriniz {managerTitle} tərəfindən idarə olunur. Əgər şəxsiyyət vəsiqənizdəki ad hesabınızdakı adla uyğun gəlmirsə, kömək üçün {profileDataManager} administratorunuzla və ya {support} ilə əlaqə saxlayın.",
   "idv.submission.alert.error": "ID təsdiqini təqdim etməyə çalışarkən texniki bir səhv baş verdi. Bu müvəqqəti bir problem ola bilər, ona görə də bir neçə dəqiqədən sonra yenidən cəhd edin. Problem davam edərsə, kömək üçün {support_link} keçidinə daxil olun.",
-  "id.verification.account.name.edit": "Redaktə edin {sr}"
+  "id.verification.account.name.edit": "Redaktə edin {sr}",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/bo.json
+++ b/translations/frontend-app-account/src/i18n/messages/bo.json
@@ -336,5 +336,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "ལག་ལེན་འཐབ་ཐུབ་པ།",
   "soa_footer_main.support": "རོགས་རམ་དང་གདུང་སེམས།",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/da.json
+++ b/translations/frontend-app-account/src/i18n/messages/da.json
@@ -361,5 +361,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Tilgængelighed",
   "soa_footer_main.support": "Support og Hjælp",
-  "soa_footer_main.allRightReserved": "Eftertryk forbudt"
+  "soa_footer_main.allRightReserved": "Eftertryk forbudt",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/de.json
+++ b/translations/frontend-app-account/src/i18n/messages/de.json
@@ -357,5 +357,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Barrierefreiheit",
   "soa_footer_main.support": "Support und Hilfe",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/de_DE.json
+++ b/translations/frontend-app-account/src/i18n/messages/de_DE.json
@@ -336,5 +336,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Barrierefreiheit",
   "soa_footer_main.support": "Support und Hilfe",
-  "soa_footer_main.allRightReserved": "Alle Rechte vorbehalten"
+  "soa_footer_main.allRightReserved": "Alle Rechte vorbehalten",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/el.json
+++ b/translations/frontend-app-account/src/i18n/messages/el.json
@@ -336,5 +336,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Προσβασιμότητα",
   "soa_footer_main.support": "Υποστήριξη και Βοήθεια",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/es_419.json
+++ b/translations/frontend-app-account/src/i18n/messages/es_419.json
@@ -336,5 +336,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accesibilidad",
   "soa_footer_main.support": "Soporte y Ayuda",
-  "soa_footer_main.allRightReserved": "Todos los derechos reservados."
+  "soa_footer_main.allRightReserved": "Todos los derechos reservados.",
+  "header.menu.soa.myLearning.label": "Mi aprendizaje"
 }

--- a/translations/frontend-app-account/src/i18n/messages/es_ES.json
+++ b/translations/frontend-app-account/src/i18n/messages/es_ES.json
@@ -336,5 +336,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accesibilidad",
   "soa_footer_main.support": "Soporte y Ayuda",
-  "soa_footer_main.allRightReserved": "Todos los derechos están reservados"
+  "soa_footer_main.allRightReserved": "Todos los derechos están reservados",
+  "header.menu.soa.myLearning.label": "Mi aprendizaje"
 }

--- a/translations/frontend-app-account/src/i18n/messages/fa.json
+++ b/translations/frontend-app-account/src/i18n/messages/fa.json
@@ -336,5 +336,6 @@
   "soa_footer_main.cookies": "کوکی‌ها",
   "soa_footer_main.accessibility": "دسترس‌پذیری",
   "soa_footer_main.support": "پشتیبانی و کمک",
-  "soa_footer_main.allRightReserved": "تمامی حقوق محفوظ است"
+  "soa_footer_main.allRightReserved": "تمامی حقوق محفوظ است",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/fr_CA.json
+++ b/translations/frontend-app-account/src/i18n/messages/fr_CA.json
@@ -336,5 +336,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accessibilité",
   "soa_footer_main.support": "Soutien et Aide",
-  "soa_footer_main.allRightReserved": "Tous droits réservés"
+  "soa_footer_main.allRightReserved": "Tous droits réservés",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/he.json
+++ b/translations/frontend-app-account/src/i18n/messages/he.json
@@ -361,5 +361,6 @@
   "soa_footer_main.cookies": "עוגיות",
   "soa_footer_main.accessibility": "נגישות",
   "soa_footer_main.support": "תמיכה ועזרה",
-  "soa_footer_main.allRightReserved": "כל הזכויות שמורות"
+  "soa_footer_main.allRightReserved": "כל הזכויות שמורות",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/hi.json
+++ b/translations/frontend-app-account/src/i18n/messages/hi.json
@@ -336,5 +336,6 @@
   "soa_footer_main.cookies": "कुकीज़",
   "soa_footer_main.accessibility": "अभिगम्यता",
   "soa_footer_main.support": "सहायता और मदद",
-  "soa_footer_main.allRightReserved": "सभी अधिकार सुरक्षित"
+  "soa_footer_main.allRightReserved": "सभी अधिकार सुरक्षित",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/hu.json
+++ b/translations/frontend-app-account/src/i18n/messages/hu.json
@@ -336,5 +336,6 @@
   "soa_footer_main.cookies": "Sütik",
   "soa_footer_main.accessibility": "Akadálymentesség",
   "soa_footer_main.support": "Támogatás és Segítség",
-  "soa_footer_main.allRightReserved": "Minden jog fenntartva"
+  "soa_footer_main.allRightReserved": "Minden jog fenntartva",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/id.json
+++ b/translations/frontend-app-account/src/i18n/messages/id.json
@@ -361,5 +361,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Aksesibilitas",
   "soa_footer_main.support": "Dukungan dan Bantuan",
-  "soa_footer_main.allRightReserved": "Seluruh hak cipta"
+  "soa_footer_main.allRightReserved": "Seluruh hak cipta",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/it_IT.json
+++ b/translations/frontend-app-account/src/i18n/messages/it_IT.json
@@ -336,5 +336,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "Accessibilità",
   "soa_footer_main.support": "Supporto e Aiuto",
-  "soa_footer_main.allRightReserved": "Tutti i diritti riservati"
+  "soa_footer_main.allRightReserved": "Tutti i diritti riservati",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/ja.json
+++ b/translations/frontend-app-account/src/i18n/messages/ja.json
@@ -336,5 +336,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "アクセシビリティ",
   "soa_footer_main.support": "サポートとヘルプ",
-  "soa_footer_main.allRightReserved": "すべての権利を保有"
+  "soa_footer_main.allRightReserved": "すべての権利を保有",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/lv.json
+++ b/translations/frontend-app-account/src/i18n/messages/lv.json
@@ -336,5 +336,6 @@
   "soa_footer_main.cookies": "Sīkdatnes",
   "soa_footer_main.accessibility": "Pieejamība",
   "soa_footer_main.support": "Atbalsts un Palīdzība",
-  "soa_footer_main.allRightReserved": "Visas tiesības aizsargātas"
+  "soa_footer_main.allRightReserved": "Visas tiesības aizsargātas",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/pt_BR.json
+++ b/translations/frontend-app-account/src/i18n/messages/pt_BR.json
@@ -361,5 +361,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Acessibilidade",
   "soa_footer_main.support": "Suporte e Ajuda",
-  "soa_footer_main.allRightReserved": "Todos os direitos reservados"
+  "soa_footer_main.allRightReserved": "Todos os direitos reservados",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/pt_PT.json
+++ b/translations/frontend-app-account/src/i18n/messages/pt_PT.json
@@ -336,5 +336,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Acessibilidade",
   "soa_footer_main.support": "Suporte e Ajuda",
-  "soa_footer_main.allRightReserved": "Todos os direitos reservados"
+  "soa_footer_main.allRightReserved": "Todos os direitos reservados",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/ro.json
+++ b/translations/frontend-app-account/src/i18n/messages/ro.json
@@ -336,5 +336,6 @@
   "soa_footer_main.cookies": "Cookie-uri",
   "soa_footer_main.accessibility": "Accesibilitate",
   "soa_footer_main.support": "Suport și Ajutor",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/ru.json
+++ b/translations/frontend-app-account/src/i18n/messages/ru.json
@@ -361,5 +361,6 @@
   "soa_footer_main.cookies": "Куки",
   "soa_footer_main.accessibility": "Доступность",
   "soa_footer_main.support": "Поддержка и Помощь",
-  "soa_footer_main.allRightReserved": "Все права защищены"
+  "soa_footer_main.allRightReserved": "Все права защищены",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/sv.json
+++ b/translations/frontend-app-account/src/i18n/messages/sv.json
@@ -336,5 +336,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Tillgänglighet",
   "soa_footer_main.support": "Support och Hjälp",
-  "soa_footer_main.allRightReserved": "Alla rättigheter förbehållna"
+  "soa_footer_main.allRightReserved": "Alla rättigheter förbehållna",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/sw.json
+++ b/translations/frontend-app-account/src/i18n/messages/sw.json
@@ -361,5 +361,6 @@
   "soa_footer_main.cookies": "Vidakuzi",
   "soa_footer_main.accessibility": "Upatikanaji",
   "soa_footer_main.support": "Msaada na Usaidizi",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/te.json
+++ b/translations/frontend-app-account/src/i18n/messages/te.json
@@ -361,5 +361,6 @@
   "soa_footer_main.cookies": "కుకీలు",
   "soa_footer_main.accessibility": "అందుబాటు",
   "soa_footer_main.support": "మద్దతు మరియు సహాయం",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/th.json
+++ b/translations/frontend-app-account/src/i18n/messages/th.json
@@ -361,5 +361,6 @@
   "soa_footer_main.cookies": "คุกกี้",
   "soa_footer_main.accessibility": "การเข้าถึง",
   "soa_footer_main.support": "การสนับสนุนและความช่วยเหลือ",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/tr_TR.json
+++ b/translations/frontend-app-account/src/i18n/messages/tr_TR.json
@@ -336,5 +336,6 @@
   "soa_footer_main.cookies": "Çerezler",
   "soa_footer_main.accessibility": "Erişilebilirlik",
   "soa_footer_main.support": "Destek ve Yardım",
-  "soa_footer_main.allRightReserved": "Tüm hakları saklıdır"
+  "soa_footer_main.allRightReserved": "Tüm hakları saklıdır",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/uk.json
+++ b/translations/frontend-app-account/src/i18n/messages/uk.json
@@ -336,5 +336,6 @@
   "soa_footer_main.cookies": "Файли cookie",
   "soa_footer_main.accessibility": "Доступність",
   "soa_footer_main.support": "Підтримка та Допомога",
-  "soa_footer_main.allRightReserved": "Всі права захищено"
+  "soa_footer_main.allRightReserved": "Всі права захищено",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/uz.json
+++ b/translations/frontend-app-account/src/i18n/messages/uz.json
@@ -336,5 +336,6 @@
   "soa_footer_main.cookies": "Kukilar",
   "soa_footer_main.accessibility": "Imkoniyat",
   "soa_footer_main.support": "Qo'llab-quvvatlash va Yordam",
-  "soa_footer_main.allRightReserved": "Barcha huquqlar himoyalangan"
+  "soa_footer_main.allRightReserved": "Barcha huquqlar himoyalangan",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/vi.json
+++ b/translations/frontend-app-account/src/i18n/messages/vi.json
@@ -336,5 +336,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "Khả năng tiếp cận",
   "soa_footer_main.support": "Hỗ trợ và Trợ giúp",
-  "soa_footer_main.allRightReserved": "Đã đăng ký Bản quyền"
+  "soa_footer_main.allRightReserved": "Đã đăng ký Bản quyền",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/zh_CN.json
+++ b/translations/frontend-app-account/src/i18n/messages/zh_CN.json
@@ -336,5 +336,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "无障碍",
   "soa_footer_main.support": "支持与帮助",
-  "soa_footer_main.allRightReserved": "保留所有权利"
+  "soa_footer_main.allRightReserved": "保留所有权利",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/messages/zh_HK.json
+++ b/translations/frontend-app-account/src/i18n/messages/zh_HK.json
@@ -336,5 +336,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "無障礙",
   "soa_footer_main.support": "支援與幫助",
-  "soa_footer_main.allRightReserved": "版權所有"
+  "soa_footer_main.allRightReserved": "版權所有",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-account/src/i18n/transifex_input.json
+++ b/translations/frontend-app-account/src/i18n/transifex_input.json
@@ -336,5 +336,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accessibility",
   "soa_footer_main.support": "Support and Help",
-  "soa_footer_main.allRightReserved": "All rights reserved"
+  "soa_footer_main.allRightReserved": "All rights reserved",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/af_ZA.json
+++ b/translations/frontend-app-authn/src/i18n/messages/af_ZA.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Koekies",
   "soa_footer_main.accessibility": "Toeganklikheid",
   "soa_footer_main.support": "Ondersteuning en Hulp",
-  "soa_footer_main.allRightReserved": "Alle regte voorbehou"
+  "soa_footer_main.allRightReserved": "Alle regte voorbehou",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/ar.json
+++ b/translations/frontend-app-authn/src/i18n/messages/ar.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "ملفات تعريف الارتباط",
   "soa_footer_main.accessibility": "إمكانية الوصول",
   "soa_footer_main.support": "الدعم والمساعدة",
-  "soa_footer_main.allRightReserved": "جميع الحقوق محفوظة"
+  "soa_footer_main.allRightReserved": "جميع الحقوق محفوظة",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/az.json
+++ b/translations/frontend-app-authn/src/i18n/messages/az.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Kukilər",
   "soa_footer_main.accessibility": "Əlçatanlıq",
   "soa_footer_main.support": "Dəstək və Yardım",
-  "soa_footer_main.allRightReserved": "Bütün hüquqlar qorunur"
+  "soa_footer_main.allRightReserved": "Bütün hüquqlar qorunur",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/da.json
+++ b/translations/frontend-app-authn/src/i18n/messages/da.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Tilgængelighed",
   "soa_footer_main.support": "Support og Hjælp",
-  "soa_footer_main.allRightReserved": "Eftertryk forbudt"
+  "soa_footer_main.allRightReserved": "Eftertryk forbudt",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/de.json
+++ b/translations/frontend-app-authn/src/i18n/messages/de.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Barrierefreiheit",
   "soa_footer_main.support": "Support und Hilfe",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/de_DE.json
+++ b/translations/frontend-app-authn/src/i18n/messages/de_DE.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Barrierefreiheit",
   "soa_footer_main.support": "Support und Hilfe",
-  "soa_footer_main.allRightReserved": "Alle Rechte vorbehalten"
+  "soa_footer_main.allRightReserved": "Alle Rechte vorbehalten",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/el.json
+++ b/translations/frontend-app-authn/src/i18n/messages/el.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Προσβασιμότητα",
   "soa_footer_main.support": "Υποστήριξη και Βοήθεια",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/es_419.json
+++ b/translations/frontend-app-authn/src/i18n/messages/es_419.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accesibilidad",
   "soa_footer_main.support": "Soporte y Ayuda",
-  "soa_footer_main.allRightReserved": "Todos los derechos reservados."
+  "soa_footer_main.allRightReserved": "Todos los derechos reservados.",
+  "header.menu.soa.myLearning.label": "Mi aprendizaje"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/es_ES.json
+++ b/translations/frontend-app-authn/src/i18n/messages/es_ES.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accesibilidad",
   "soa_footer_main.support": "Soporte y Ayuda",
-  "soa_footer_main.allRightReserved": "Todos los derechos están reservados"
+  "soa_footer_main.allRightReserved": "Todos los derechos están reservados",
+  "header.menu.soa.myLearning.label": "Mi aprendizaje"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/fa.json
+++ b/translations/frontend-app-authn/src/i18n/messages/fa.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "کوکی‌ها",
   "soa_footer_main.accessibility": "دسترس‌پذیری",
   "soa_footer_main.support": "پشتیبانی و کمک",
-  "soa_footer_main.allRightReserved": "تمامی حقوق محفوظ است"
+  "soa_footer_main.allRightReserved": "تمامی حقوق محفوظ است",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/fr_CA.json
+++ b/translations/frontend-app-authn/src/i18n/messages/fr_CA.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accessibilité",
   "soa_footer_main.support": "Soutien et Aide",
-  "soa_footer_main.allRightReserved": "Tous droits réservés"
+  "soa_footer_main.allRightReserved": "Tous droits réservés",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/he.json
+++ b/translations/frontend-app-authn/src/i18n/messages/he.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "עוגיות",
   "soa_footer_main.accessibility": "נגישות",
   "soa_footer_main.support": "תמיכה ועזרה",
-  "soa_footer_main.allRightReserved": "כל הזכויות שמורות"
+  "soa_footer_main.allRightReserved": "כל הזכויות שמורות",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/hi.json
+++ b/translations/frontend-app-authn/src/i18n/messages/hi.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "कुकीज़",
   "soa_footer_main.accessibility": "अभिगम्यता",
   "soa_footer_main.support": "सहायता और मदद",
-  "soa_footer_main.allRightReserved": "सभी अधिकार सुरक्षित"
+  "soa_footer_main.allRightReserved": "सभी अधिकार सुरक्षित",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/hu.json
+++ b/translations/frontend-app-authn/src/i18n/messages/hu.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Sütik",
   "soa_footer_main.accessibility": "Akadálymentesség",
   "soa_footer_main.support": "Támogatás és Segítség",
-  "soa_footer_main.allRightReserved": "Minden jog fenntartva"
+  "soa_footer_main.allRightReserved": "Minden jog fenntartva",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/id.json
+++ b/translations/frontend-app-authn/src/i18n/messages/id.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Aksesibilitas",
   "soa_footer_main.support": "Dukungan dan Bantuan",
-  "soa_footer_main.allRightReserved": "Seluruh hak cipta"
+  "soa_footer_main.allRightReserved": "Seluruh hak cipta",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/it_IT.json
+++ b/translations/frontend-app-authn/src/i18n/messages/it_IT.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "Accessibilità",
   "soa_footer_main.support": "Supporto e Aiuto",
-  "soa_footer_main.allRightReserved": "Tutti i diritti riservati"
+  "soa_footer_main.allRightReserved": "Tutti i diritti riservati",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/ja.json
+++ b/translations/frontend-app-authn/src/i18n/messages/ja.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "アクセシビリティ",
   "soa_footer_main.support": "サポートとヘルプ",
-  "soa_footer_main.allRightReserved": "すべての権利を保有"
+  "soa_footer_main.allRightReserved": "すべての権利を保有",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/lv.json
+++ b/translations/frontend-app-authn/src/i18n/messages/lv.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Sīkdatnes",
   "soa_footer_main.accessibility": "Pieejamība",
   "soa_footer_main.support": "Atbalsts un Palīdzība",
-  "soa_footer_main.allRightReserved": "Visas tiesības aizsargātas"
+  "soa_footer_main.allRightReserved": "Visas tiesības aizsargātas",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/pt_BR.json
+++ b/translations/frontend-app-authn/src/i18n/messages/pt_BR.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Acessibilidade",
   "soa_footer_main.support": "Suporte e Ajuda",
-  "soa_footer_main.allRightReserved": "Todos os direitos reservados"
+  "soa_footer_main.allRightReserved": "Todos os direitos reservados",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/pt_PT.json
+++ b/translations/frontend-app-authn/src/i18n/messages/pt_PT.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Acessibilidade",
   "soa_footer_main.support": "Suporte e Ajuda",
-  "soa_footer_main.allRightReserved": "Todos os direitos reservados"
+  "soa_footer_main.allRightReserved": "Todos os direitos reservados",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/ro.json
+++ b/translations/frontend-app-authn/src/i18n/messages/ro.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Cookie-uri",
   "soa_footer_main.accessibility": "Accesibilitate",
   "soa_footer_main.support": "Suport și Ajutor",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/ru.json
+++ b/translations/frontend-app-authn/src/i18n/messages/ru.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Куки",
   "soa_footer_main.accessibility": "Доступность",
   "soa_footer_main.support": "Поддержка и Помощь",
-  "soa_footer_main.allRightReserved": "Все права защищены"
+  "soa_footer_main.allRightReserved": "Все права защищены",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/sv.json
+++ b/translations/frontend-app-authn/src/i18n/messages/sv.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Tillgänglighet",
   "soa_footer_main.support": "Support och Hjälp",
-  "soa_footer_main.allRightReserved": "Alla rättigheter förbehållna"
+  "soa_footer_main.allRightReserved": "Alla rättigheter förbehållna",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/sw.json
+++ b/translations/frontend-app-authn/src/i18n/messages/sw.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Vidakuzi",
   "soa_footer_main.accessibility": "Upatikanaji",
   "soa_footer_main.support": "Msaada na Usaidizi",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/te.json
+++ b/translations/frontend-app-authn/src/i18n/messages/te.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "కుకీలు",
   "soa_footer_main.accessibility": "అందుబాటు",
   "soa_footer_main.support": "మద్దతు మరియు సహాయం",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/th.json
+++ b/translations/frontend-app-authn/src/i18n/messages/th.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "คุกกี้",
   "soa_footer_main.accessibility": "การเข้าถึง",
   "soa_footer_main.support": "การสนับสนุนและความช่วยเหลือ",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/tr_TR.json
+++ b/translations/frontend-app-authn/src/i18n/messages/tr_TR.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Çerezler",
   "soa_footer_main.accessibility": "Erişilebilirlik",
   "soa_footer_main.support": "Destek ve Yardım",
-  "soa_footer_main.allRightReserved": "Tüm hakları saklıdır"
+  "soa_footer_main.allRightReserved": "Tüm hakları saklıdır",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/uk.json
+++ b/translations/frontend-app-authn/src/i18n/messages/uk.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Файли cookie",
   "soa_footer_main.accessibility": "Доступність",
   "soa_footer_main.support": "Підтримка та Допомога",
-  "soa_footer_main.allRightReserved": "Всі права захищено"
+  "soa_footer_main.allRightReserved": "Всі права захищено",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/uz.json
+++ b/translations/frontend-app-authn/src/i18n/messages/uz.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Kukilar",
   "soa_footer_main.accessibility": "Imkoniyat",
   "soa_footer_main.support": "Qo'llab-quvvatlash va Yordam",
-  "soa_footer_main.allRightReserved": "Barcha huquqlar himoyalangan"
+  "soa_footer_main.allRightReserved": "Barcha huquqlar himoyalangan",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/vi.json
+++ b/translations/frontend-app-authn/src/i18n/messages/vi.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "Khả năng tiếp cận",
   "soa_footer_main.support": "Hỗ trợ và Trợ giúp",
-  "soa_footer_main.allRightReserved": "Đã đăng ký Bản quyền"
+  "soa_footer_main.allRightReserved": "Đã đăng ký Bản quyền",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/zh_CN.json
+++ b/translations/frontend-app-authn/src/i18n/messages/zh_CN.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "无障碍",
   "soa_footer_main.support": "支持与帮助",
-  "soa_footer_main.allRightReserved": "保留所有权利"
+  "soa_footer_main.allRightReserved": "保留所有权利",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/zh_HK.json
+++ b/translations/frontend-app-authn/src/i18n/messages/zh_HK.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "無障礙",
   "soa_footer_main.support": "支援與幫助",
-  "soa_footer_main.allRightReserved": "版權所有"
+  "soa_footer_main.allRightReserved": "版權所有",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-authn/src/i18n/transifex_input.json
+++ b/translations/frontend-app-authn/src/i18n/transifex_input.json
@@ -184,5 +184,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accessibility",
   "soa_footer_main.support": "Support and Help",
-  "soa_footer_main.allRightReserved": "All rights reserved"
+  "soa_footer_main.allRightReserved": "All rights reserved",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/af_ZA.json
+++ b/translations/frontend-app-communications/src/i18n/messages/af_ZA.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Koekies",
   "soa_footer_main.accessibility": "Toeganklikheid",
   "soa_footer_main.support": "Ondersteuning en Hulp",
-  "soa_footer_main.allRightReserved": "Alle regte voorbehou"
+  "soa_footer_main.allRightReserved": "Alle regte voorbehou",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/ar.json
+++ b/translations/frontend-app-communications/src/i18n/messages/ar.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "ملفات تعريف الارتباط",
   "soa_footer_main.accessibility": "إمكانية الوصول",
   "soa_footer_main.support": "الدعم والمساعدة",
-  "soa_footer_main.allRightReserved": "جميع الحقوق محفوظة"
+  "soa_footer_main.allRightReserved": "جميع الحقوق محفوظة",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/az.json
+++ b/translations/frontend-app-communications/src/i18n/messages/az.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Kukilər",
   "soa_footer_main.accessibility": "Əlçatanlıq",
   "soa_footer_main.support": "Dəstək və Yardım",
-  "soa_footer_main.allRightReserved": "Bütün hüquqlar qorunur"
+  "soa_footer_main.allRightReserved": "Bütün hüquqlar qorunur",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/bo.json
+++ b/translations/frontend-app-communications/src/i18n/messages/bo.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "ལག་ལེན་འཐབ་ཐུབ་པ།",
   "soa_footer_main.support": "རོགས་རམ་དང་གདུང་སེམས།",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/da.json
+++ b/translations/frontend-app-communications/src/i18n/messages/da.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Tilgængelighed",
   "soa_footer_main.support": "Support og Hjælp",
-  "soa_footer_main.allRightReserved": "Eftertryk forbudt"
+  "soa_footer_main.allRightReserved": "Eftertryk forbudt",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/de_DE.json
+++ b/translations/frontend-app-communications/src/i18n/messages/de_DE.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Barrierefreiheit",
   "soa_footer_main.support": "Support und Hilfe",
-  "soa_footer_main.allRightReserved": "Alle Rechte vorbehalten"
+  "soa_footer_main.allRightReserved": "Alle Rechte vorbehalten",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/el.json
+++ b/translations/frontend-app-communications/src/i18n/messages/el.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Προσβασιμότητα",
   "soa_footer_main.support": "Υποστήριξη και Βοήθεια",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/es_419.json
+++ b/translations/frontend-app-communications/src/i18n/messages/es_419.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accesibilidad",
   "soa_footer_main.support": "Soporte y Ayuda",
-  "soa_footer_main.allRightReserved": "Todos los derechos reservados."
+  "soa_footer_main.allRightReserved": "Todos los derechos reservados.",
+  "header.menu.soa.myLearning.label": "Mi aprendizaje"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/es_ES.json
+++ b/translations/frontend-app-communications/src/i18n/messages/es_ES.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accesibilidad",
   "soa_footer_main.support": "Soporte y Ayuda",
-  "soa_footer_main.allRightReserved": "Todos los derechos están reservados"
+  "soa_footer_main.allRightReserved": "Todos los derechos están reservados",
+  "header.menu.soa.myLearning.label": "Mi aprendizaje"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/fa.json
+++ b/translations/frontend-app-communications/src/i18n/messages/fa.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "کوکی‌ها",
   "soa_footer_main.accessibility": "دسترس‌پذیری",
   "soa_footer_main.support": "پشتیبانی و کمک",
-  "soa_footer_main.allRightReserved": "تمامی حقوق محفوظ است"
+  "soa_footer_main.allRightReserved": "تمامی حقوق محفوظ است",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/fr_CA.json
+++ b/translations/frontend-app-communications/src/i18n/messages/fr_CA.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accessibilité",
   "soa_footer_main.support": "Soutien et Aide",
-  "soa_footer_main.allRightReserved": "Tous droits réservés"
+  "soa_footer_main.allRightReserved": "Tous droits réservés",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/he.json
+++ b/translations/frontend-app-communications/src/i18n/messages/he.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "עוגיות",
   "soa_footer_main.accessibility": "נגישות",
   "soa_footer_main.support": "תמיכה ועזרה",
-  "soa_footer_main.allRightReserved": "כל הזכויות שמורות"
+  "soa_footer_main.allRightReserved": "כל הזכויות שמורות",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/hi.json
+++ b/translations/frontend-app-communications/src/i18n/messages/hi.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "कुकीज़",
   "soa_footer_main.accessibility": "अभिगम्यता",
   "soa_footer_main.support": "सहायता और मदद",
-  "soa_footer_main.allRightReserved": "सभी अधिकार सुरक्षित"
+  "soa_footer_main.allRightReserved": "सभी अधिकार सुरक्षित",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/hu.json
+++ b/translations/frontend-app-communications/src/i18n/messages/hu.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Sütik",
   "soa_footer_main.accessibility": "Akadálymentesség",
   "soa_footer_main.support": "Támogatás és Segítség",
-  "soa_footer_main.allRightReserved": "Minden jog fenntartva"
+  "soa_footer_main.allRightReserved": "Minden jog fenntartva",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/id.json
+++ b/translations/frontend-app-communications/src/i18n/messages/id.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Aksesibilitas",
   "soa_footer_main.support": "Dukungan dan Bantuan",
-  "soa_footer_main.allRightReserved": "Seluruh hak cipta"
+  "soa_footer_main.allRightReserved": "Seluruh hak cipta",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/it_IT.json
+++ b/translations/frontend-app-communications/src/i18n/messages/it_IT.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "Accessibilità",
   "soa_footer_main.support": "Supporto e Aiuto",
-  "soa_footer_main.allRightReserved": "Tutti i diritti riservati"
+  "soa_footer_main.allRightReserved": "Tutti i diritti riservati",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/ja.json
+++ b/translations/frontend-app-communications/src/i18n/messages/ja.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "アクセシビリティ",
   "soa_footer_main.support": "サポートとヘルプ",
-  "soa_footer_main.allRightReserved": "すべての権利を保有"
+  "soa_footer_main.allRightReserved": "すべての権利を保有",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/lv.json
+++ b/translations/frontend-app-communications/src/i18n/messages/lv.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Sīkdatnes",
   "soa_footer_main.accessibility": "Pieejamība",
   "soa_footer_main.support": "Atbalsts un Palīdzība",
-  "soa_footer_main.allRightReserved": "Visas tiesības aizsargātas"
+  "soa_footer_main.allRightReserved": "Visas tiesības aizsargātas",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/pt_BR.json
+++ b/translations/frontend-app-communications/src/i18n/messages/pt_BR.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Acessibilidade",
   "soa_footer_main.support": "Suporte e Ajuda",
-  "soa_footer_main.allRightReserved": "Todos os direitos reservados"
+  "soa_footer_main.allRightReserved": "Todos os direitos reservados",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/pt_PT.json
+++ b/translations/frontend-app-communications/src/i18n/messages/pt_PT.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Acessibilidade",
   "soa_footer_main.support": "Suporte e Ajuda",
-  "soa_footer_main.allRightReserved": "Todos os direitos reservados"
+  "soa_footer_main.allRightReserved": "Todos os direitos reservados",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/ru.json
+++ b/translations/frontend-app-communications/src/i18n/messages/ru.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Куки",
   "soa_footer_main.accessibility": "Доступность",
   "soa_footer_main.support": "Поддержка и Помощь",
-  "soa_footer_main.allRightReserved": "Все права защищены"
+  "soa_footer_main.allRightReserved": "Все права защищены",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/sv.json
+++ b/translations/frontend-app-communications/src/i18n/messages/sv.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Tillgänglighet",
   "soa_footer_main.support": "Support och Hjälp",
-  "soa_footer_main.allRightReserved": "Alla rättigheter förbehållna"
+  "soa_footer_main.allRightReserved": "Alla rättigheter förbehållna",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/sw.json
+++ b/translations/frontend-app-communications/src/i18n/messages/sw.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Vidakuzi",
   "soa_footer_main.accessibility": "Upatikanaji",
   "soa_footer_main.support": "Msaada na Usaidizi",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/te.json
+++ b/translations/frontend-app-communications/src/i18n/messages/te.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "కుకీలు",
   "soa_footer_main.accessibility": "అందుబాటు",
   "soa_footer_main.support": "మద్దతు మరియు సహాయం",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/th.json
+++ b/translations/frontend-app-communications/src/i18n/messages/th.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "คุกกี้",
   "soa_footer_main.accessibility": "การเข้าถึง",
   "soa_footer_main.support": "การสนับสนุนและความช่วยเหลือ",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/tr_TR.json
+++ b/translations/frontend-app-communications/src/i18n/messages/tr_TR.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Çerezler",
   "soa_footer_main.accessibility": "Erişilebilirlik",
   "soa_footer_main.support": "Destek ve Yardım",
-  "soa_footer_main.allRightReserved": "Tüm hakları saklıdır"
+  "soa_footer_main.allRightReserved": "Tüm hakları saklıdır",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/uk.json
+++ b/translations/frontend-app-communications/src/i18n/messages/uk.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Файли cookie",
   "soa_footer_main.accessibility": "Доступність",
   "soa_footer_main.support": "Підтримка та Допомога",
-  "soa_footer_main.allRightReserved": "Всі права захищено"
+  "soa_footer_main.allRightReserved": "Всі права захищено",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/uz.json
+++ b/translations/frontend-app-communications/src/i18n/messages/uz.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Kukilar",
   "soa_footer_main.accessibility": "Imkoniyat",
   "soa_footer_main.support": "Qo'llab-quvvatlash va Yordam",
-  "soa_footer_main.allRightReserved": "Barcha huquqlar himoyalangan"
+  "soa_footer_main.allRightReserved": "Barcha huquqlar himoyalangan",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/vi.json
+++ b/translations/frontend-app-communications/src/i18n/messages/vi.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "Khả năng tiếp cận",
   "soa_footer_main.support": "Hỗ trợ và Trợ giúp",
-  "soa_footer_main.allRightReserved": "Đã đăng ký Bản quyền"
+  "soa_footer_main.allRightReserved": "Đã đăng ký Bản quyền",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/zh_CN.json
+++ b/translations/frontend-app-communications/src/i18n/messages/zh_CN.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "无障碍",
   "soa_footer_main.support": "支持与帮助",
-  "soa_footer_main.allRightReserved": "保留所有权利"
+  "soa_footer_main.allRightReserved": "保留所有权利",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/messages/zh_HK.json
+++ b/translations/frontend-app-communications/src/i18n/messages/zh_HK.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "無障礙",
   "soa_footer_main.support": "支援與幫助",
-  "soa_footer_main.allRightReserved": "版權所有"
+  "soa_footer_main.allRightReserved": "版權所有",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-communications/src/i18n/transifex_input.json
+++ b/translations/frontend-app-communications/src/i18n/transifex_input.json
@@ -94,5 +94,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accessibility",
   "soa_footer_main.support": "Support and Help",
-  "soa_footer_main.allRightReserved": "All rights reserved"
+  "soa_footer_main.allRightReserved": "All rights reserved",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/af_ZA.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/af_ZA.json
@@ -1742,5 +1742,6 @@
   "soa_footer_main.cookies": "Koekies",
   "soa_footer_main.accessibility": "Toeganklikheid",
   "soa_footer_main.support": "Ondersteuning en Hulp",
-  "soa_footer_main.allRightReserved": "Alle regte voorbehou"
+  "soa_footer_main.allRightReserved": "Alle regte voorbehou",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/ar.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/ar.json
@@ -1742,5 +1742,6 @@
   "soa_footer_main.cookies": "ملفات تعريف الارتباط",
   "soa_footer_main.accessibility": "إمكانية الوصول",
   "soa_footer_main.support": "الدعم والمساعدة",
-  "soa_footer_main.allRightReserved": "جميع الحقوق محفوظة"
+  "soa_footer_main.allRightReserved": "جميع الحقوق محفوظة",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/az.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/az.json
@@ -1735,5 +1735,6 @@
   "problemEditor.settings.tolerance.answerrangewarning": "",
   "problemEditor.settings.tolerance.type.percent": "Faiz",
   "problemEditor.settings.tolerance.type.number": "Rəqəm",
-  "problemEditor.settings.tolerance.type.none": "Heç biri"
+  "problemEditor.settings.tolerance.type.none": "Heç biri",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/da.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/da.json
@@ -1357,5 +1357,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Tilgængelighed",
   "soa_footer_main.support": "Support og Hjælp",
-  "soa_footer_main.allRightReserved": "Eftertryk forbudt"
+  "soa_footer_main.allRightReserved": "Eftertryk forbudt",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/de.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/de.json
@@ -663,5 +663,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Barrierefreiheit",
   "soa_footer_main.support": "Support und Hilfe",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/de_DE.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/de_DE.json
@@ -1742,5 +1742,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Barrierefreiheit",
   "soa_footer_main.support": "Support und Hilfe",
-  "soa_footer_main.allRightReserved": "Alle Rechte vorbehalten"
+  "soa_footer_main.allRightReserved": "Alle Rechte vorbehalten",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/el.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/el.json
@@ -1357,5 +1357,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Προσβασιμότητα",
   "soa_footer_main.support": "Υποστήριξη και Βοήθεια",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/es_419.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/es_419.json
@@ -1742,5 +1742,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accesibilidad",
   "soa_footer_main.support": "Soporte y Ayuda",
-  "soa_footer_main.allRightReserved": "Todos los derechos reservados."
+  "soa_footer_main.allRightReserved": "Todos los derechos reservados.",
+  "header.menu.soa.myLearning.label": "Mi aprendizaje"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/es_ES.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/es_ES.json
@@ -1742,5 +1742,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accesibilidad",
   "soa_footer_main.support": "Soporte y Ayuda",
-  "soa_footer_main.allRightReserved": "Todos los derechos están reservados"
+  "soa_footer_main.allRightReserved": "Todos los derechos están reservados",
+  "header.menu.soa.myLearning.label": "Mi aprendizaje"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/fa.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/fa.json
@@ -1742,5 +1742,6 @@
   "soa_footer_main.cookies": "کوکی‌ها",
   "soa_footer_main.accessibility": "دسترس‌پذیری",
   "soa_footer_main.support": "پشتیبانی و کمک",
-  "soa_footer_main.allRightReserved": "تمامی حقوق محفوظ است"
+  "soa_footer_main.allRightReserved": "تمامی حقوق محفوظ است",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/fr_CA.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/fr_CA.json
@@ -1742,5 +1742,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accessibilité",
   "soa_footer_main.support": "Soutien et Aide",
-  "soa_footer_main.allRightReserved": "Tous droits réservés"
+  "soa_footer_main.allRightReserved": "Tous droits réservés",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/he.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/he.json
@@ -1357,5 +1357,6 @@
   "soa_footer_main.cookies": "עוגיות",
   "soa_footer_main.accessibility": "נגישות",
   "soa_footer_main.support": "תמיכה ועזרה",
-  "soa_footer_main.allRightReserved": "כל הזכויות שמורות"
+  "soa_footer_main.allRightReserved": "כל הזכויות שמורות",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/hi.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/hi.json
@@ -1742,5 +1742,6 @@
   "soa_footer_main.cookies": "कुकीज़",
   "soa_footer_main.accessibility": "अभिगम्यता",
   "soa_footer_main.support": "सहायता और मदद",
-  "soa_footer_main.allRightReserved": "सभी अधिकार सुरक्षित"
+  "soa_footer_main.allRightReserved": "सभी अधिकार सुरक्षित",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/hu.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/hu.json
@@ -1742,5 +1742,6 @@
   "soa_footer_main.cookies": "Sütik",
   "soa_footer_main.accessibility": "Akadálymentesség",
   "soa_footer_main.support": "Támogatás és Segítség",
-  "soa_footer_main.allRightReserved": "Minden jog fenntartva"
+  "soa_footer_main.allRightReserved": "Minden jog fenntartva",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/id.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/id.json
@@ -1357,5 +1357,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Aksesibilitas",
   "soa_footer_main.support": "Dukungan dan Bantuan",
-  "soa_footer_main.allRightReserved": "Seluruh hak cipta"
+  "soa_footer_main.allRightReserved": "Seluruh hak cipta",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/it_IT.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/it_IT.json
@@ -1357,5 +1357,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "Accessibilità",
   "soa_footer_main.support": "Supporto e Aiuto",
-  "soa_footer_main.allRightReserved": "Tutti i diritti riservati"
+  "soa_footer_main.allRightReserved": "Tutti i diritti riservati",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/ja.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/ja.json
@@ -1742,5 +1742,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "アクセシビリティ",
   "soa_footer_main.support": "サポートとヘルプ",
-  "soa_footer_main.allRightReserved": "すべての権利を保有"
+  "soa_footer_main.allRightReserved": "すべての権利を保有",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/lv.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/lv.json
@@ -1742,5 +1742,6 @@
   "soa_footer_main.cookies": "Sīkdatnes",
   "soa_footer_main.accessibility": "Pieejamība",
   "soa_footer_main.support": "Atbalsts un Palīdzība",
-  "soa_footer_main.allRightReserved": "Visas tiesības aizsargātas"
+  "soa_footer_main.allRightReserved": "Visas tiesības aizsargātas",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/pt_BR.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/pt_BR.json
@@ -1357,5 +1357,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Acessibilidade",
   "soa_footer_main.support": "Suporte e Ajuda",
-  "soa_footer_main.allRightReserved": "Todos os direitos reservados"
+  "soa_footer_main.allRightReserved": "Todos os direitos reservados",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/pt_PT.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/pt_PT.json
@@ -1742,5 +1742,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Acessibilidade",
   "soa_footer_main.support": "Suporte e Ajuda",
-  "soa_footer_main.allRightReserved": "Todos os direitos reservados"
+  "soa_footer_main.allRightReserved": "Todos os direitos reservados",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/ru.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/ru.json
@@ -1742,5 +1742,6 @@
   "soa_footer_main.cookies": "Куки",
   "soa_footer_main.accessibility": "Доступность",
   "soa_footer_main.support": "Поддержка и Помощь",
-  "soa_footer_main.allRightReserved": "Все права защищены"
+  "soa_footer_main.allRightReserved": "Все права защищены",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/sq.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/sq.json
@@ -1736,5 +1736,6 @@
   "problemEditor.settings.tolerance.type.percent": "",
   "problemEditor.settings.tolerance.type.number": "",
   "problemEditor.settings.tolerance.type.none": "",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/sv.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/sv.json
@@ -1742,5 +1742,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Tillgänglighet",
   "soa_footer_main.support": "Support och Hjälp",
-  "soa_footer_main.allRightReserved": "Alla rättigheter förbehållna"
+  "soa_footer_main.allRightReserved": "Alla rättigheter förbehållna",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/sw.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/sw.json
@@ -1357,5 +1357,6 @@
   "soa_footer_main.cookies": "Vidakuzi",
   "soa_footer_main.accessibility": "Upatikanaji",
   "soa_footer_main.support": "Msaada na Usaidizi",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/te.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/te.json
@@ -1357,5 +1357,6 @@
   "soa_footer_main.cookies": "కుకీలు",
   "soa_footer_main.accessibility": "అందుబాటు",
   "soa_footer_main.support": "మద్దతు మరియు సహాయం",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/th.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/th.json
@@ -1357,5 +1357,6 @@
   "soa_footer_main.cookies": "คุกกี้",
   "soa_footer_main.accessibility": "การเข้าถึง",
   "soa_footer_main.support": "การสนับสนุนและความช่วยเหลือ",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/tr_TR.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/tr_TR.json
@@ -1742,5 +1742,6 @@
   "soa_footer_main.cookies": "Çerezler",
   "soa_footer_main.accessibility": "Erişilebilirlik",
   "soa_footer_main.support": "Destek ve Yardım",
-  "soa_footer_main.allRightReserved": "Tüm hakları saklıdır"
+  "soa_footer_main.allRightReserved": "Tüm hakları saklıdır",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/uk.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/uk.json
@@ -1742,5 +1742,6 @@
   "soa_footer_main.cookies": "Файли cookie",
   "soa_footer_main.accessibility": "Доступність",
   "soa_footer_main.support": "Підтримка та Допомога",
-  "soa_footer_main.allRightReserved": "Всі права захищено"
+  "soa_footer_main.allRightReserved": "Всі права захищено",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/uz.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/uz.json
@@ -1742,5 +1742,6 @@
   "soa_footer_main.cookies": "Kukilar",
   "soa_footer_main.accessibility": "Imkoniyat",
   "soa_footer_main.support": "Qo'llab-quvvatlash va Yordam",
-  "soa_footer_main.allRightReserved": "Barcha huquqlar himoyalangan"
+  "soa_footer_main.allRightReserved": "Barcha huquqlar himoyalangan",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/vi.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/vi.json
@@ -1742,5 +1742,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "Khả năng tiếp cận",
   "soa_footer_main.support": "Hỗ trợ và Trợ giúp",
-  "soa_footer_main.allRightReserved": "Đã đăng ký Bản quyền"
+  "soa_footer_main.allRightReserved": "Đã đăng ký Bản quyền",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/zh_CN.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/zh_CN.json
@@ -1742,5 +1742,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "无障碍",
   "soa_footer_main.support": "支持与帮助",
-  "soa_footer_main.allRightReserved": "保留所有权利"
+  "soa_footer_main.allRightReserved": "保留所有权利",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/messages/zh_HK.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/zh_HK.json
@@ -1742,5 +1742,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "無障礙",
   "soa_footer_main.support": "支援與幫助",
-  "soa_footer_main.allRightReserved": "版權所有"
+  "soa_footer_main.allRightReserved": "版權所有",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/transifex_input.json
+++ b/translations/frontend-app-course-authoring/src/i18n/transifex_input.json
@@ -1742,5 +1742,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accessibility",
   "soa_footer_main.support": "Support and Help",
-  "soa_footer_main.allRightReserved": "All rights reserved"
+  "soa_footer_main.allRightReserved": "All rights reserved",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/af_ZA.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/af_ZA.json
@@ -223,5 +223,6 @@
   "soa_footer_main.cookies": "Koekies",
   "soa_footer_main.accessibility": "Toeganklikheid",
   "soa_footer_main.support": "Ondersteuning en Hulp",
-  "soa_footer_main.allRightReserved": "Alle regte voorbehou"
+  "soa_footer_main.allRightReserved": "Alle regte voorbehou",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/ar.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/ar.json
@@ -223,5 +223,6 @@
   "soa_footer_main.cookies": "ملفات تعريف الارتباط",
   "soa_footer_main.accessibility": "إمكانية الوصول",
   "soa_footer_main.support": "الدعم والمساعدة",
-  "soa_footer_main.allRightReserved": "جميع الحقوق محفوظة"
+  "soa_footer_main.allRightReserved": "جميع الحقوق محفوظة",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/az.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/az.json
@@ -223,5 +223,6 @@
   "soa_footer_main.cookies": "Kukilər",
   "soa_footer_main.accessibility": "Əlçatanlıq",
   "soa_footer_main.support": "Dəstək və Yardım",
-  "soa_footer_main.allRightReserved": "Bütün hüquqlar qorunur"
+  "soa_footer_main.allRightReserved": "Bütün hüquqlar qorunur",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/da.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/da.json
@@ -216,5 +216,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Tilgængelighed",
   "soa_footer_main.support": "Support og Hjælp",
-  "soa_footer_main.allRightReserved": "Eftertryk forbudt"
+  "soa_footer_main.allRightReserved": "Eftertryk forbudt",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/de.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/de.json
@@ -214,5 +214,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Barrierefreiheit",
   "soa_footer_main.support": "Support und Hilfe",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/de_DE.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/de_DE.json
@@ -223,5 +223,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Barrierefreiheit",
   "soa_footer_main.support": "Support und Hilfe",
-  "soa_footer_main.allRightReserved": "Alle Rechte vorbehalten"
+  "soa_footer_main.allRightReserved": "Alle Rechte vorbehalten",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/el.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/el.json
@@ -216,5 +216,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Προσβασιμότητα",
   "soa_footer_main.support": "Υποστήριξη και Βοήθεια",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/es_419.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/es_419.json
@@ -223,5 +223,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accesibilidad",
   "soa_footer_main.support": "Soporte y Ayuda",
-  "soa_footer_main.allRightReserved": "Todos los derechos reservados."
+  "soa_footer_main.allRightReserved": "Todos los derechos reservados.",
+  "header.menu.soa.myLearning.label": "Mi aprendizaje"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/es_ES.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/es_ES.json
@@ -223,5 +223,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accesibilidad",
   "soa_footer_main.support": "Soporte y Ayuda",
-  "soa_footer_main.allRightReserved": "Todos los derechos están reservados"
+  "soa_footer_main.allRightReserved": "Todos los derechos están reservados",
+  "header.menu.soa.myLearning.label": "Mi aprendizaje"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/fa.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/fa.json
@@ -223,5 +223,6 @@
   "soa_footer_main.cookies": "کوکی‌ها",
   "soa_footer_main.accessibility": "دسترس‌پذیری",
   "soa_footer_main.support": "پشتیبانی و کمک",
-  "soa_footer_main.allRightReserved": "تمامی حقوق محفوظ است"
+  "soa_footer_main.allRightReserved": "تمامی حقوق محفوظ است",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/fr_CA.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/fr_CA.json
@@ -223,5 +223,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accessibilité",
   "soa_footer_main.support": "Soutien et Aide",
-  "soa_footer_main.allRightReserved": "Tous droits réservés"
+  "soa_footer_main.allRightReserved": "Tous droits réservés",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/he.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/he.json
@@ -216,5 +216,6 @@
   "soa_footer_main.cookies": "עוגיות",
   "soa_footer_main.accessibility": "נגישות",
   "soa_footer_main.support": "תמיכה ועזרה",
-  "soa_footer_main.allRightReserved": "כל הזכויות שמורות"
+  "soa_footer_main.allRightReserved": "כל הזכויות שמורות",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/hi.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/hi.json
@@ -223,5 +223,6 @@
   "soa_footer_main.cookies": "कुकीज़",
   "soa_footer_main.accessibility": "अभिगम्यता",
   "soa_footer_main.support": "सहायता और मदद",
-  "soa_footer_main.allRightReserved": "सभी अधिकार सुरक्षित"
+  "soa_footer_main.allRightReserved": "सभी अधिकार सुरक्षित",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/hu.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/hu.json
@@ -223,5 +223,6 @@
   "soa_footer_main.cookies": "Sütik",
   "soa_footer_main.accessibility": "Akadálymentesség",
   "soa_footer_main.support": "Támogatás és Segítség",
-  "soa_footer_main.allRightReserved": "Minden jog fenntartva"
+  "soa_footer_main.allRightReserved": "Minden jog fenntartva",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/id.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/id.json
@@ -216,5 +216,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Aksesibilitas",
   "soa_footer_main.support": "Dukungan dan Bantuan",
-  "soa_footer_main.allRightReserved": "Seluruh hak cipta"
+  "soa_footer_main.allRightReserved": "Seluruh hak cipta",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/it_IT.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/it_IT.json
@@ -223,5 +223,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "Accessibilità",
   "soa_footer_main.support": "Supporto e Aiuto",
-  "soa_footer_main.allRightReserved": "Tutti i diritti riservati"
+  "soa_footer_main.allRightReserved": "Tutti i diritti riservati",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/ja.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/ja.json
@@ -223,5 +223,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "アクセシビリティ",
   "soa_footer_main.support": "サポートとヘルプ",
-  "soa_footer_main.allRightReserved": "すべての権利を保有"
+  "soa_footer_main.allRightReserved": "すべての権利を保有",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/lv.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/lv.json
@@ -223,5 +223,6 @@
   "soa_footer_main.cookies": "Sīkdatnes",
   "soa_footer_main.accessibility": "Pieejamība",
   "soa_footer_main.support": "Atbalsts un Palīdzība",
-  "soa_footer_main.allRightReserved": "Visas tiesības aizsargātas"
+  "soa_footer_main.allRightReserved": "Visas tiesības aizsargātas",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/pt_BR.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/pt_BR.json
@@ -216,5 +216,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Acessibilidade",
   "soa_footer_main.support": "Suporte e Ajuda",
-  "soa_footer_main.allRightReserved": "Todos os direitos reservados"
+  "soa_footer_main.allRightReserved": "Todos os direitos reservados",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/pt_PT.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/pt_PT.json
@@ -223,5 +223,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Acessibilidade",
   "soa_footer_main.support": "Suporte e Ajuda",
-  "soa_footer_main.allRightReserved": "Todos os direitos reservados"
+  "soa_footer_main.allRightReserved": "Todos os direitos reservados",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/ro.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/ro.json
@@ -223,5 +223,6 @@
   "soa_footer_main.cookies": "Cookie-uri",
   "soa_footer_main.accessibility": "Accesibilitate",
   "soa_footer_main.support": "Suport și Ajutor",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/ru.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/ru.json
@@ -216,5 +216,6 @@
   "soa_footer_main.cookies": "Куки",
   "soa_footer_main.accessibility": "Доступность",
   "soa_footer_main.support": "Поддержка и Помощь",
-  "soa_footer_main.allRightReserved": "Все права защищены"
+  "soa_footer_main.allRightReserved": "Все права защищены",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/sv.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/sv.json
@@ -223,5 +223,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Tillgänglighet",
   "soa_footer_main.support": "Support och Hjälp",
-  "soa_footer_main.allRightReserved": "Alla rättigheter förbehållna"
+  "soa_footer_main.allRightReserved": "Alla rättigheter förbehållna",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/sw.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/sw.json
@@ -216,5 +216,6 @@
   "soa_footer_main.cookies": "Vidakuzi",
   "soa_footer_main.accessibility": "Upatikanaji",
   "soa_footer_main.support": "Msaada na Usaidizi",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/te.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/te.json
@@ -216,5 +216,6 @@
   "soa_footer_main.cookies": "కుకీలు",
   "soa_footer_main.accessibility": "అందుబాటు",
   "soa_footer_main.support": "మద్దతు మరియు సహాయం",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/th.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/th.json
@@ -216,5 +216,6 @@
   "soa_footer_main.cookies": "คุกกี้",
   "soa_footer_main.accessibility": "การเข้าถึง",
   "soa_footer_main.support": "การสนับสนุนและความช่วยเหลือ",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/tr_TR.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/tr_TR.json
@@ -223,5 +223,6 @@
   "soa_footer_main.cookies": "Çerezler",
   "soa_footer_main.accessibility": "Erişilebilirlik",
   "soa_footer_main.support": "Destek ve Yardım",
-  "soa_footer_main.allRightReserved": "Tüm hakları saklıdır"
+  "soa_footer_main.allRightReserved": "Tüm hakları saklıdır",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/uk.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/uk.json
@@ -223,5 +223,6 @@
   "soa_footer_main.cookies": "Файли cookie",
   "soa_footer_main.accessibility": "Доступність",
   "soa_footer_main.support": "Підтримка та Допомога",
-  "soa_footer_main.allRightReserved": "Всі права захищено"
+  "soa_footer_main.allRightReserved": "Всі права захищено",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/uz.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/uz.json
@@ -223,5 +223,6 @@
   "soa_footer_main.cookies": "Kukilar",
   "soa_footer_main.accessibility": "Imkoniyat",
   "soa_footer_main.support": "Qo'llab-quvvatlash va Yordam",
-  "soa_footer_main.allRightReserved": "Barcha huquqlar himoyalangan"
+  "soa_footer_main.allRightReserved": "Barcha huquqlar himoyalangan",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/vi.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/vi.json
@@ -223,5 +223,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "Khả năng tiếp cận",
   "soa_footer_main.support": "Hỗ trợ và Trợ giúp",
-  "soa_footer_main.allRightReserved": "Đã đăng ký Bản quyền"
+  "soa_footer_main.allRightReserved": "Đã đăng ký Bản quyền",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/zh_CN.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/zh_CN.json
@@ -223,5 +223,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "无障碍",
   "soa_footer_main.support": "支持与帮助",
-  "soa_footer_main.allRightReserved": "保留所有权利"
+  "soa_footer_main.allRightReserved": "保留所有权利",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/messages/zh_HK.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/zh_HK.json
@@ -223,5 +223,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "無障礙",
   "soa_footer_main.support": "支援與幫助",
-  "soa_footer_main.allRightReserved": "版權所有"
+  "soa_footer_main.allRightReserved": "版權所有",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-discussions/src/i18n/transifex_input.json
+++ b/translations/frontend-app-discussions/src/i18n/transifex_input.json
@@ -223,5 +223,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accessibility",
   "soa_footer_main.support": "Support and Help",
-  "soa_footer_main.allRightReserved": "All rights reserved"
+  "soa_footer_main.allRightReserved": "All rights reserved",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/af_ZA.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/af_ZA.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Koekies",
   "soa_footer_main.accessibility": "Toeganklikheid",
   "soa_footer_main.support": "Ondersteuning en Hulp",
-  "soa_footer_main.allRightReserved": "Alle regte voorbehou"
+  "soa_footer_main.allRightReserved": "Alle regte voorbehou",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/ar.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/ar.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "ملفات تعريف الارتباط",
   "soa_footer_main.accessibility": "إمكانية الوصول",
   "soa_footer_main.support": "الدعم والمساعدة",
-  "soa_footer_main.allRightReserved": "جميع الحقوق محفوظة"
+  "soa_footer_main.allRightReserved": "جميع الحقوق محفوظة",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/az.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/az.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Kukilər",
   "soa_footer_main.accessibility": "Əlçatanlıq",
   "soa_footer_main.support": "Dəstək və Yardım",
-  "soa_footer_main.allRightReserved": "Bütün hüquqlar qorunur"
+  "soa_footer_main.allRightReserved": "Bütün hüquqlar qorunur",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/da.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/da.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Tilgængelighed",
   "soa_footer_main.support": "Support og Hjælp",
-  "soa_footer_main.allRightReserved": "Eftertryk forbudt"
+  "soa_footer_main.allRightReserved": "Eftertryk forbudt",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/de.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/de.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Barrierefreiheit",
   "soa_footer_main.support": "Support und Hilfe",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/de_DE.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/de_DE.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Barrierefreiheit",
   "soa_footer_main.support": "Support und Hilfe",
-  "soa_footer_main.allRightReserved": "Alle Rechte vorbehalten"
+  "soa_footer_main.allRightReserved": "Alle Rechte vorbehalten",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/el.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/el.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Προσβασιμότητα",
   "soa_footer_main.support": "Υποστήριξη και Βοήθεια",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/es_419.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/es_419.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accesibilidad",
   "soa_footer_main.support": "Soporte y Ayuda",
-  "soa_footer_main.allRightReserved": "Todos los derechos reservados."
+  "soa_footer_main.allRightReserved": "Todos los derechos reservados.",
+  "header.menu.soa.myLearning.label": "Mi aprendizaje"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/es_ES.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/es_ES.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accesibilidad",
   "soa_footer_main.support": "Soporte y Ayuda",
-  "soa_footer_main.allRightReserved": "Todos los derechos están reservados"
+  "soa_footer_main.allRightReserved": "Todos los derechos están reservados",
+  "header.menu.soa.myLearning.label": "Mi aprendizaje"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/fa.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/fa.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "کوکی‌ها",
   "soa_footer_main.accessibility": "دسترس‌پذیری",
   "soa_footer_main.support": "پشتیبانی و کمک",
-  "soa_footer_main.allRightReserved": "تمامی حقوق محفوظ است"
+  "soa_footer_main.allRightReserved": "تمامی حقوق محفوظ است",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/fr_CA.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/fr_CA.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accessibilité",
   "soa_footer_main.support": "Soutien et Aide",
-  "soa_footer_main.allRightReserved": "Tous droits réservés"
+  "soa_footer_main.allRightReserved": "Tous droits réservés",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/he.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/he.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "עוגיות",
   "soa_footer_main.accessibility": "נגישות",
   "soa_footer_main.support": "תמיכה ועזרה",
-  "soa_footer_main.allRightReserved": "כל הזכויות שמורות"
+  "soa_footer_main.allRightReserved": "כל הזכויות שמורות",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/hi.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/hi.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "कुकीज़",
   "soa_footer_main.accessibility": "अभिगम्यता",
   "soa_footer_main.support": "सहायता और मदद",
-  "soa_footer_main.allRightReserved": "सभी अधिकार सुरक्षित"
+  "soa_footer_main.allRightReserved": "सभी अधिकार सुरक्षित",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/hu.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/hu.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Sütik",
   "soa_footer_main.accessibility": "Akadálymentesség",
   "soa_footer_main.support": "Támogatás és Segítség",
-  "soa_footer_main.allRightReserved": "Minden jog fenntartva"
+  "soa_footer_main.allRightReserved": "Minden jog fenntartva",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/id.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/id.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Aksesibilitas",
   "soa_footer_main.support": "Dukungan dan Bantuan",
-  "soa_footer_main.allRightReserved": "Seluruh hak cipta"
+  "soa_footer_main.allRightReserved": "Seluruh hak cipta",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/it_IT.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/it_IT.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "Accessibilità",
   "soa_footer_main.support": "Supporto e Aiuto",
-  "soa_footer_main.allRightReserved": "Tutti i diritti riservati"
+  "soa_footer_main.allRightReserved": "Tutti i diritti riservati",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/ja.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/ja.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "アクセシビリティ",
   "soa_footer_main.support": "サポートとヘルプ",
-  "soa_footer_main.allRightReserved": "すべての権利を保有"
+  "soa_footer_main.allRightReserved": "すべての権利を保有",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/lv.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/lv.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Sīkdatnes",
   "soa_footer_main.accessibility": "Pieejamība",
   "soa_footer_main.support": "Atbalsts un Palīdzība",
-  "soa_footer_main.allRightReserved": "Visas tiesības aizsargātas"
+  "soa_footer_main.allRightReserved": "Visas tiesības aizsargātas",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/pt_BR.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/pt_BR.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Acessibilidade",
   "soa_footer_main.support": "Suporte e Ajuda",
-  "soa_footer_main.allRightReserved": "Todos os direitos reservados"
+  "soa_footer_main.allRightReserved": "Todos os direitos reservados",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/pt_PT.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/pt_PT.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Acessibilidade",
   "soa_footer_main.support": "Suporte e Ajuda",
-  "soa_footer_main.allRightReserved": "Todos os direitos reservados"
+  "soa_footer_main.allRightReserved": "Todos os direitos reservados",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/ru.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/ru.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Куки",
   "soa_footer_main.accessibility": "Доступность",
   "soa_footer_main.support": "Поддержка и Помощь",
-  "soa_footer_main.allRightReserved": "Все права защищены"
+  "soa_footer_main.allRightReserved": "Все права защищены",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/sv.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/sv.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Tillgänglighet",
   "soa_footer_main.support": "Support och Hjälp",
-  "soa_footer_main.allRightReserved": "Alla rättigheter förbehållna"
+  "soa_footer_main.allRightReserved": "Alla rättigheter förbehållna",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/sw.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/sw.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Vidakuzi",
   "soa_footer_main.accessibility": "Upatikanaji",
   "soa_footer_main.support": "Msaada na Usaidizi",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/te.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/te.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "కుకీలు",
   "soa_footer_main.accessibility": "అందుబాటు",
   "soa_footer_main.support": "మద్దతు మరియు సహాయం",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/th.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/th.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "คุกกี้",
   "soa_footer_main.accessibility": "การเข้าถึง",
   "soa_footer_main.support": "การสนับสนุนและความช่วยเหลือ",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/tr_TR.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/tr_TR.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Çerezler",
   "soa_footer_main.accessibility": "Erişilebilirlik",
   "soa_footer_main.support": "Destek ve Yardım",
-  "soa_footer_main.allRightReserved": "Tüm hakları saklıdır"
+  "soa_footer_main.allRightReserved": "Tüm hakları saklıdır",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/uk.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/uk.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Файли cookie",
   "soa_footer_main.accessibility": "Доступність",
   "soa_footer_main.support": "Підтримка та Допомога",
-  "soa_footer_main.allRightReserved": "Всі права захищено"
+  "soa_footer_main.allRightReserved": "Всі права захищено",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/uz.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/uz.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Kukilar",
   "soa_footer_main.accessibility": "Imkoniyat",
   "soa_footer_main.support": "Qo'llab-quvvatlash va Yordam",
-  "soa_footer_main.allRightReserved": "Barcha huquqlar himoyalangan"
+  "soa_footer_main.allRightReserved": "Barcha huquqlar himoyalangan",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/vi.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/vi.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "Khả năng tiếp cận",
   "soa_footer_main.support": "Hỗ trợ và Trợ giúp",
-  "soa_footer_main.allRightReserved": "Đã đăng ký Bản quyền"
+  "soa_footer_main.allRightReserved": "Đã đăng ký Bản quyền",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/zh_CN.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/zh_CN.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "无障碍",
   "soa_footer_main.support": "支持与帮助",
-  "soa_footer_main.allRightReserved": "保留所有权利"
+  "soa_footer_main.allRightReserved": "保留所有权利",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/messages/zh_HK.json
+++ b/translations/frontend-app-gradebook/src/i18n/messages/zh_HK.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "無障礙",
   "soa_footer_main.support": "支援與幫助",
-  "soa_footer_main.allRightReserved": "版權所有"
+  "soa_footer_main.allRightReserved": "版權所有",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-gradebook/src/i18n/transifex_input.json
+++ b/translations/frontend-app-gradebook/src/i18n/transifex_input.json
@@ -80,5 +80,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accessibility",
   "soa_footer_main.support": "Support and Help",
-  "soa_footer_main.allRightReserved": "All rights reserved"
+  "soa_footer_main.allRightReserved": "All rights reserved",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/af_ZA.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/af_ZA.json
@@ -149,5 +149,6 @@
   "soa_footer_main.cookies": "Koekies",
   "soa_footer_main.accessibility": "Toeganklikheid",
   "soa_footer_main.support": "Ondersteuning en Hulp",
-  "soa_footer_main.allRightReserved": "Alle regte voorbehou"
+  "soa_footer_main.allRightReserved": "Alle regte voorbehou",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/ar.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/ar.json
@@ -149,5 +149,6 @@
   "soa_footer_main.cookies": "ملفات تعريف الارتباط",
   "soa_footer_main.accessibility": "إمكانية الوصول",
   "soa_footer_main.support": "الدعم والمساعدة",
-  "soa_footer_main.allRightReserved": "جميع الحقوق محفوظة"
+  "soa_footer_main.allRightReserved": "جميع الحقوق محفوظة",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/az.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/az.json
@@ -149,5 +149,6 @@
   "soa_footer_main.cookies": "Kukilər",
   "soa_footer_main.accessibility": "Əlçatanlıq",
   "soa_footer_main.support": "Dəstək və Yardım",
-  "soa_footer_main.allRightReserved": "Bütün hüquqlar qorunur"
+  "soa_footer_main.allRightReserved": "Bütün hüquqlar qorunur",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/bo.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/bo.json
@@ -149,5 +149,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "ལག་ལེན་འཐབ་ཐུབ་པ།",
   "soa_footer_main.support": "རོགས་རམ་དང་གདུང་སེམས།",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/da.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/da.json
@@ -159,5 +159,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Tilgængelighed",
   "soa_footer_main.support": "Support og Hjælp",
-  "soa_footer_main.allRightReserved": "Eftertryk forbudt"
+  "soa_footer_main.allRightReserved": "Eftertryk forbudt",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/de.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/de.json
@@ -60,5 +60,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Barrierefreiheit",
   "soa_footer_main.support": "Support und Hilfe",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/de_DE.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/de_DE.json
@@ -149,5 +149,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Barrierefreiheit",
   "soa_footer_main.support": "Support und Hilfe",
-  "soa_footer_main.allRightReserved": "Alle Rechte vorbehalten"
+  "soa_footer_main.allRightReserved": "Alle Rechte vorbehalten",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/el.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/el.json
@@ -159,5 +159,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Προσβασιμότητα",
   "soa_footer_main.support": "Υποστήριξη και Βοήθεια",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/es_419.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/es_419.json
@@ -149,5 +149,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accesibilidad",
   "soa_footer_main.support": "Soporte y Ayuda",
-  "soa_footer_main.allRightReserved": "Todos los derechos reservados."
+  "soa_footer_main.allRightReserved": "Todos los derechos reservados.",
+  "header.menu.soa.myLearning.label": "Mi aprendizaje"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/es_ES.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/es_ES.json
@@ -149,5 +149,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accesibilidad",
   "soa_footer_main.support": "Soporte y Ayuda",
-  "soa_footer_main.allRightReserved": "Todos los derechos están reservados"
+  "soa_footer_main.allRightReserved": "Todos los derechos están reservados",
+  "header.menu.soa.myLearning.label": "Mi aprendizaje"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/fa.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/fa.json
@@ -149,5 +149,6 @@
   "soa_footer_main.cookies": "کوکی‌ها",
   "soa_footer_main.accessibility": "دسترس‌پذیری",
   "soa_footer_main.support": "پشتیبانی و کمک",
-  "soa_footer_main.allRightReserved": "تمامی حقوق محفوظ است"
+  "soa_footer_main.allRightReserved": "تمامی حقوق محفوظ است",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/fr.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/fr.json
@@ -143,5 +143,6 @@
   "learner-dash.courseCard.banners.credit.requestCredit": "Demander un crédit",
   "learner-dash.courseCard.banners.credit.viewCredit": "Voir le crédit",
   "learner-dash.courseCard.banners.credit.viewDetails": "Voir les détails",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/fr_CA.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/fr_CA.json
@@ -149,5 +149,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accessibilité",
   "soa_footer_main.support": "Soutien et Aide",
-  "soa_footer_main.allRightReserved": "Tous droits réservés"
+  "soa_footer_main.allRightReserved": "Tous droits réservés",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/he.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/he.json
@@ -159,5 +159,6 @@
   "soa_footer_main.cookies": "עוגיות",
   "soa_footer_main.accessibility": "נגישות",
   "soa_footer_main.support": "תמיכה ועזרה",
-  "soa_footer_main.allRightReserved": "כל הזכויות שמורות"
+  "soa_footer_main.allRightReserved": "כל הזכויות שמורות",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/hi.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/hi.json
@@ -149,5 +149,6 @@
   "soa_footer_main.cookies": "कुकीज़",
   "soa_footer_main.accessibility": "अभिगम्यता",
   "soa_footer_main.support": "सहायता और मदद",
-  "soa_footer_main.allRightReserved": "सभी अधिकार सुरक्षित"
+  "soa_footer_main.allRightReserved": "सभी अधिकार सुरक्षित",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/hu.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/hu.json
@@ -149,5 +149,6 @@
   "soa_footer_main.cookies": "Sütik",
   "soa_footer_main.accessibility": "Akadálymentesség",
   "soa_footer_main.support": "Támogatás és Segítség",
-  "soa_footer_main.allRightReserved": "Minden jog fenntartva"
+  "soa_footer_main.allRightReserved": "Minden jog fenntartva",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/id.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/id.json
@@ -159,5 +159,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Aksesibilitas",
   "soa_footer_main.support": "Dukungan dan Bantuan",
-  "soa_footer_main.allRightReserved": "Seluruh hak cipta"
+  "soa_footer_main.allRightReserved": "Seluruh hak cipta",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/it_IT.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/it_IT.json
@@ -159,5 +159,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "Accessibilità",
   "soa_footer_main.support": "Supporto e Aiuto",
-  "soa_footer_main.allRightReserved": "Tutti i diritti riservati"
+  "soa_footer_main.allRightReserved": "Tutti i diritti riservati",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/ja.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/ja.json
@@ -149,5 +149,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "アクセシビリティ",
   "soa_footer_main.support": "サポートとヘルプ",
-  "soa_footer_main.allRightReserved": "すべての権利を保有"
+  "soa_footer_main.allRightReserved": "すべての権利を保有",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/kk.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/kk.json
@@ -143,5 +143,6 @@
   "learner-dash.courseCard.banners.credit.requestCredit": "Кредит сұрау",
   "learner-dash.courseCard.banners.credit.viewCredit": "Кредитті көру",
   "learner-dash.courseCard.banners.credit.viewDetails": "Мәліметтерді көру",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/lv.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/lv.json
@@ -149,5 +149,6 @@
   "soa_footer_main.cookies": "Sīkdatnes",
   "soa_footer_main.accessibility": "Pieejamība",
   "soa_footer_main.support": "Atbalsts un Palīdzība",
-  "soa_footer_main.allRightReserved": "Visas tiesības aizsargātas"
+  "soa_footer_main.allRightReserved": "Visas tiesības aizsargātas",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/pt_BR.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/pt_BR.json
@@ -159,5 +159,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Acessibilidade",
   "soa_footer_main.support": "Suporte e Ajuda",
-  "soa_footer_main.allRightReserved": "Todos os direitos reservados"
+  "soa_footer_main.allRightReserved": "Todos os direitos reservados",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/pt_PT.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/pt_PT.json
@@ -149,5 +149,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Acessibilidade",
   "soa_footer_main.support": "Suporte e Ajuda",
-  "soa_footer_main.allRightReserved": "Todos os direitos reservados"
+  "soa_footer_main.allRightReserved": "Todos os direitos reservados",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/ro.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/ro.json
@@ -149,5 +149,6 @@
   "soa_footer_main.cookies": "Cookie-uri",
   "soa_footer_main.accessibility": "Accesibilitate",
   "soa_footer_main.support": "Suport și Ajutor",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/ru.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/ru.json
@@ -149,5 +149,6 @@
   "soa_footer_main.cookies": "Куки",
   "soa_footer_main.accessibility": "Доступность",
   "soa_footer_main.support": "Поддержка и Помощь",
-  "soa_footer_main.allRightReserved": "Все права защищены"
+  "soa_footer_main.allRightReserved": "Все права защищены",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/sv.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/sv.json
@@ -149,5 +149,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Tillgänglighet",
   "soa_footer_main.support": "Support och Hjälp",
-  "soa_footer_main.allRightReserved": "Alla rättigheter förbehållna"
+  "soa_footer_main.allRightReserved": "Alla rättigheter förbehållna",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/sw.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/sw.json
@@ -159,5 +159,6 @@
   "soa_footer_main.cookies": "Vidakuzi",
   "soa_footer_main.accessibility": "Upatikanaji",
   "soa_footer_main.support": "Msaada na Usaidizi",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/te.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/te.json
@@ -159,5 +159,6 @@
   "soa_footer_main.cookies": "కుకీలు",
   "soa_footer_main.accessibility": "అందుబాటు",
   "soa_footer_main.support": "మద్దతు మరియు సహాయం",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/th.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/th.json
@@ -159,5 +159,6 @@
   "soa_footer_main.cookies": "คุกกี้",
   "soa_footer_main.accessibility": "การเข้าถึง",
   "soa_footer_main.support": "การสนับสนุนและความช่วยเหลือ",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/tr_TR.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/tr_TR.json
@@ -149,5 +149,6 @@
   "soa_footer_main.cookies": "Çerezler",
   "soa_footer_main.accessibility": "Erişilebilirlik",
   "soa_footer_main.support": "Destek ve Yardım",
-  "soa_footer_main.allRightReserved": "Tüm hakları saklıdır"
+  "soa_footer_main.allRightReserved": "Tüm hakları saklıdır",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/uk.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/uk.json
@@ -149,5 +149,6 @@
   "soa_footer_main.cookies": "Файли cookie",
   "soa_footer_main.accessibility": "Доступність",
   "soa_footer_main.support": "Підтримка та Допомога",
-  "soa_footer_main.allRightReserved": "Всі права захищено"
+  "soa_footer_main.allRightReserved": "Всі права захищено",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/uz.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/uz.json
@@ -149,5 +149,6 @@
   "soa_footer_main.cookies": "Kukilar",
   "soa_footer_main.accessibility": "Imkoniyat",
   "soa_footer_main.support": "Qo'llab-quvvatlash va Yordam",
-  "soa_footer_main.allRightReserved": "Barcha huquqlar himoyalangan"
+  "soa_footer_main.allRightReserved": "Barcha huquqlar himoyalangan",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/vi.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/vi.json
@@ -149,5 +149,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "Khả năng tiếp cận",
   "soa_footer_main.support": "Hỗ trợ và Trợ giúp",
-  "soa_footer_main.allRightReserved": "Đã đăng ký Bản quyền"
+  "soa_footer_main.allRightReserved": "Đã đăng ký Bản quyền",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/zh_CN.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/zh_CN.json
@@ -159,5 +159,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "无障碍",
   "soa_footer_main.support": "支持与帮助",
-  "soa_footer_main.allRightReserved": "保留所有权利"
+  "soa_footer_main.allRightReserved": "保留所有权利",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/zh_HK.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/zh_HK.json
@@ -149,5 +149,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "無障礙",
   "soa_footer_main.support": "支援與幫助",
-  "soa_footer_main.allRightReserved": "版權所有"
+  "soa_footer_main.allRightReserved": "版權所有",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learner-dashboard/src/i18n/transifex_input.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/transifex_input.json
@@ -149,5 +149,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accessibility",
   "soa_footer_main.support": "Support and Help",
-  "soa_footer_main.allRightReserved": "All rights reserved"
+  "soa_footer_main.allRightReserved": "All rights reserved",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/af_ZA.json
+++ b/translations/frontend-app-learning/src/i18n/messages/af_ZA.json
@@ -487,5 +487,6 @@
   "soa_footer_main.cookies": "Koekies",
   "soa_footer_main.accessibility": "Toeganklikheid",
   "soa_footer_main.support": "Ondersteuning en Hulp",
-  "soa_footer_main.allRightReserved": "Alle regte voorbehou"
+  "soa_footer_main.allRightReserved": "Alle regte voorbehou",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/ar.json
+++ b/translations/frontend-app-learning/src/i18n/messages/ar.json
@@ -487,5 +487,6 @@
   "soa_footer_main.cookies": "ملفات تعريف الارتباط",
   "soa_footer_main.accessibility": "إمكانية الوصول",
   "soa_footer_main.support": "الدعم والمساعدة",
-  "soa_footer_main.allRightReserved": "جميع الحقوق محفوظة"
+  "soa_footer_main.allRightReserved": "جميع الحقوق محفوظة",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/az.json
+++ b/translations/frontend-app-learning/src/i18n/messages/az.json
@@ -487,5 +487,6 @@
   "soa_footer_main.cookies": "Kukilər",
   "soa_footer_main.accessibility": "Əlçatanlıq",
   "soa_footer_main.support": "Dəstək və Yardım",
-  "soa_footer_main.allRightReserved": "Bütün hüquqlar qorunur"
+  "soa_footer_main.allRightReserved": "Bütün hüquqlar qorunur",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/bo.json
+++ b/translations/frontend-app-learning/src/i18n/messages/bo.json
@@ -487,5 +487,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "ལག་ལེན་འཐབ་ཐུབ་པ།",
   "soa_footer_main.support": "རོགས་རམ་དང་གདུང་སེམས།",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/da.json
+++ b/translations/frontend-app-learning/src/i18n/messages/da.json
@@ -474,5 +474,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Tilgængelighed",
   "soa_footer_main.support": "Support og Hjælp",
-  "soa_footer_main.allRightReserved": "Eftertryk forbudt"
+  "soa_footer_main.allRightReserved": "Eftertryk forbudt",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/de.json
+++ b/translations/frontend-app-learning/src/i18n/messages/de.json
@@ -456,5 +456,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Barrierefreiheit",
   "soa_footer_main.support": "Support und Hilfe",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/de_DE.json
+++ b/translations/frontend-app-learning/src/i18n/messages/de_DE.json
@@ -487,5 +487,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Barrierefreiheit",
   "soa_footer_main.support": "Support und Hilfe",
-  "soa_footer_main.allRightReserved": "Alle Rechte vorbehalten"
+  "soa_footer_main.allRightReserved": "Alle Rechte vorbehalten",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/el.json
+++ b/translations/frontend-app-learning/src/i18n/messages/el.json
@@ -474,5 +474,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Προσβασιμότητα",
   "soa_footer_main.support": "Υποστήριξη και Βοήθεια",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/es_419.json
+++ b/translations/frontend-app-learning/src/i18n/messages/es_419.json
@@ -487,5 +487,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accesibilidad",
   "soa_footer_main.support": "Soporte y Ayuda",
-  "soa_footer_main.allRightReserved": "Todos los derechos reservados."
+  "soa_footer_main.allRightReserved": "Todos los derechos reservados.",
+  "header.menu.soa.myLearning.label": "Mi aprendizaje"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/es_ES.json
+++ b/translations/frontend-app-learning/src/i18n/messages/es_ES.json
@@ -130,5 +130,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accesibilidad",
   "soa_footer_main.support": "Soporte y Ayuda",
-  "soa_footer_main.allRightReserved": "Todos los derechos están reservados"
+  "soa_footer_main.allRightReserved": "Todos los derechos están reservados",
+  "header.menu.soa.myLearning.label": "Mi aprendizaje"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/fa.json
+++ b/translations/frontend-app-learning/src/i18n/messages/fa.json
@@ -130,5 +130,6 @@
   "soa_footer_main.cookies": "کوکی‌ها",
   "soa_footer_main.accessibility": "دسترس‌پذیری",
   "soa_footer_main.support": "پشتیبانی و کمک",
-  "soa_footer_main.allRightReserved": "تمامی حقوق محفوظ است"
+  "soa_footer_main.allRightReserved": "تمامی حقوق محفوظ است",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/fr_CA.json
+++ b/translations/frontend-app-learning/src/i18n/messages/fr_CA.json
@@ -487,5 +487,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accessibilité",
   "soa_footer_main.support": "Soutien et Aide",
-  "soa_footer_main.allRightReserved": "Tous droits réservés"
+  "soa_footer_main.allRightReserved": "Tous droits réservés",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/he.json
+++ b/translations/frontend-app-learning/src/i18n/messages/he.json
@@ -474,5 +474,6 @@
   "soa_footer_main.cookies": "עוגיות",
   "soa_footer_main.accessibility": "נגישות",
   "soa_footer_main.support": "תמיכה ועזרה",
-  "soa_footer_main.allRightReserved": "כל הזכויות שמורות"
+  "soa_footer_main.allRightReserved": "כל הזכויות שמורות",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/hi.json
+++ b/translations/frontend-app-learning/src/i18n/messages/hi.json
@@ -487,5 +487,6 @@
   "soa_footer_main.cookies": "कुकीज़",
   "soa_footer_main.accessibility": "अभिगम्यता",
   "soa_footer_main.support": "सहायता और मदद",
-  "soa_footer_main.allRightReserved": "सभी अधिकार सुरक्षित"
+  "soa_footer_main.allRightReserved": "सभी अधिकार सुरक्षित",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/hu.json
+++ b/translations/frontend-app-learning/src/i18n/messages/hu.json
@@ -487,5 +487,6 @@
   "soa_footer_main.cookies": "Sütik",
   "soa_footer_main.accessibility": "Akadálymentesség",
   "soa_footer_main.support": "Támogatás és Segítség",
-  "soa_footer_main.allRightReserved": "Minden jog fenntartva"
+  "soa_footer_main.allRightReserved": "Minden jog fenntartva",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/id.json
+++ b/translations/frontend-app-learning/src/i18n/messages/id.json
@@ -474,5 +474,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Aksesibilitas",
   "soa_footer_main.support": "Dukungan dan Bantuan",
-  "soa_footer_main.allRightReserved": "Seluruh hak cipta"
+  "soa_footer_main.allRightReserved": "Seluruh hak cipta",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/it_IT.json
+++ b/translations/frontend-app-learning/src/i18n/messages/it_IT.json
@@ -130,5 +130,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "Accessibilità",
   "soa_footer_main.support": "Supporto e Aiuto",
-  "soa_footer_main.allRightReserved": "Tutti i diritti riservati"
+  "soa_footer_main.allRightReserved": "Tutti i diritti riservati",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/ja.json
+++ b/translations/frontend-app-learning/src/i18n/messages/ja.json
@@ -487,5 +487,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "アクセシビリティ",
   "soa_footer_main.support": "サポートとヘルプ",
-  "soa_footer_main.allRightReserved": "すべての権利を保有"
+  "soa_footer_main.allRightReserved": "すべての権利を保有",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/lv.json
+++ b/translations/frontend-app-learning/src/i18n/messages/lv.json
@@ -130,5 +130,6 @@
   "soa_footer_main.cookies": "Sīkdatnes",
   "soa_footer_main.accessibility": "Pieejamība",
   "soa_footer_main.support": "Atbalsts un Palīdzība",
-  "soa_footer_main.allRightReserved": "Visas tiesības aizsargātas"
+  "soa_footer_main.allRightReserved": "Visas tiesības aizsargātas",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/pt_BR.json
+++ b/translations/frontend-app-learning/src/i18n/messages/pt_BR.json
@@ -474,5 +474,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Acessibilidade",
   "soa_footer_main.support": "Suporte e Ajuda",
-  "soa_footer_main.allRightReserved": "Todos os direitos reservados"
+  "soa_footer_main.allRightReserved": "Todos os direitos reservados",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/pt_PT.json
+++ b/translations/frontend-app-learning/src/i18n/messages/pt_PT.json
@@ -487,5 +487,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Acessibilidade",
   "soa_footer_main.support": "Suporte e Ajuda",
-  "soa_footer_main.allRightReserved": "Todos os direitos reservados"
+  "soa_footer_main.allRightReserved": "Todos os direitos reservados",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/ro.json
+++ b/translations/frontend-app-learning/src/i18n/messages/ro.json
@@ -487,5 +487,6 @@
   "soa_footer_main.cookies": "Cookie-uri",
   "soa_footer_main.accessibility": "Accesibilitate",
   "soa_footer_main.support": "Suport și Ajutor",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/ru.json
+++ b/translations/frontend-app-learning/src/i18n/messages/ru.json
@@ -487,5 +487,6 @@
   "soa_footer_main.cookies": "Куки",
   "soa_footer_main.accessibility": "Доступность",
   "soa_footer_main.support": "Поддержка и Помощь",
-  "soa_footer_main.allRightReserved": "Все права защищены"
+  "soa_footer_main.allRightReserved": "Все права защищены",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/sv.json
+++ b/translations/frontend-app-learning/src/i18n/messages/sv.json
@@ -487,5 +487,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Tillgänglighet",
   "soa_footer_main.support": "Support och Hjälp",
-  "soa_footer_main.allRightReserved": "Alla rättigheter förbehållna"
+  "soa_footer_main.allRightReserved": "Alla rättigheter förbehållna",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/sw.json
+++ b/translations/frontend-app-learning/src/i18n/messages/sw.json
@@ -474,5 +474,6 @@
   "soa_footer_main.cookies": "Vidakuzi",
   "soa_footer_main.accessibility": "Upatikanaji",
   "soa_footer_main.support": "Msaada na Usaidizi",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/te.json
+++ b/translations/frontend-app-learning/src/i18n/messages/te.json
@@ -474,5 +474,6 @@
   "soa_footer_main.cookies": "కుకీలు",
   "soa_footer_main.accessibility": "అందుబాటు",
   "soa_footer_main.support": "మద్దతు మరియు సహాయం",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/th.json
+++ b/translations/frontend-app-learning/src/i18n/messages/th.json
@@ -474,5 +474,6 @@
   "soa_footer_main.cookies": "คุกกี้",
   "soa_footer_main.accessibility": "การเข้าถึง",
   "soa_footer_main.support": "การสนับสนุนและความช่วยเหลือ",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/tr_TR.json
+++ b/translations/frontend-app-learning/src/i18n/messages/tr_TR.json
@@ -487,5 +487,6 @@
   "soa_footer_main.cookies": "Çerezler",
   "soa_footer_main.accessibility": "Erişilebilirlik",
   "soa_footer_main.support": "Destek ve Yardım",
-  "soa_footer_main.allRightReserved": "Tüm hakları saklıdır"
+  "soa_footer_main.allRightReserved": "Tüm hakları saklıdır",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/uk.json
+++ b/translations/frontend-app-learning/src/i18n/messages/uk.json
@@ -474,5 +474,6 @@
   "soa_footer_main.cookies": "Файли cookie",
   "soa_footer_main.accessibility": "Доступність",
   "soa_footer_main.support": "Підтримка та Допомога",
-  "soa_footer_main.allRightReserved": "Всі права захищено"
+  "soa_footer_main.allRightReserved": "Всі права захищено",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/uz.json
+++ b/translations/frontend-app-learning/src/i18n/messages/uz.json
@@ -130,5 +130,6 @@
   "soa_footer_main.cookies": "Kukilar",
   "soa_footer_main.accessibility": "Imkoniyat",
   "soa_footer_main.support": "Qo'llab-quvvatlash va Yordam",
-  "soa_footer_main.allRightReserved": "Barcha huquqlar himoyalangan"
+  "soa_footer_main.allRightReserved": "Barcha huquqlar himoyalangan",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/vi.json
+++ b/translations/frontend-app-learning/src/i18n/messages/vi.json
@@ -130,5 +130,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "Khả năng tiếp cận",
   "soa_footer_main.support": "Hỗ trợ và Trợ giúp",
-  "soa_footer_main.allRightReserved": "Đã đăng ký Bản quyền"
+  "soa_footer_main.allRightReserved": "Đã đăng ký Bản quyền",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/zh_CN.json
+++ b/translations/frontend-app-learning/src/i18n/messages/zh_CN.json
@@ -130,5 +130,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "无障碍",
   "soa_footer_main.support": "支持与帮助",
-  "soa_footer_main.allRightReserved": "保留所有权利"
+  "soa_footer_main.allRightReserved": "保留所有权利",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/messages/zh_HK.json
+++ b/translations/frontend-app-learning/src/i18n/messages/zh_HK.json
@@ -130,5 +130,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "無障礙",
   "soa_footer_main.support": "支援與幫助",
-  "soa_footer_main.allRightReserved": "版權所有"
+  "soa_footer_main.allRightReserved": "版權所有",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-learning/src/i18n/transifex_input.json
+++ b/translations/frontend-app-learning/src/i18n/transifex_input.json
@@ -487,5 +487,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accessibility",
   "soa_footer_main.support": "Support and Help",
-  "soa_footer_main.allRightReserved": "All rights reserved"
+  "soa_footer_main.allRightReserved": "All rights reserved",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/af_ZA.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/af_ZA.json
@@ -107,5 +107,6 @@
   "soa_footer_main.cookies": "Koekies",
   "soa_footer_main.accessibility": "Toeganklikheid",
   "soa_footer_main.support": "Ondersteuning en Hulp",
-  "soa_footer_main.allRightReserved": "Alle regte voorbehou"
+  "soa_footer_main.allRightReserved": "Alle regte voorbehou",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/ar.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/ar.json
@@ -107,5 +107,6 @@
   "soa_footer_main.cookies": "ملفات تعريف الارتباط",
   "soa_footer_main.accessibility": "إمكانية الوصول",
   "soa_footer_main.support": "الدعم والمساعدة",
-  "soa_footer_main.allRightReserved": "جميع الحقوق محفوظة"
+  "soa_footer_main.allRightReserved": "جميع الحقوق محفوظة",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/az.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/az.json
@@ -107,5 +107,6 @@
   "soa_footer_main.cookies": "Kukilər",
   "soa_footer_main.accessibility": "Əlçatanlıq",
   "soa_footer_main.support": "Dəstək və Yardım",
-  "soa_footer_main.allRightReserved": "Bütün hüquqlar qorunur"
+  "soa_footer_main.allRightReserved": "Bütün hüquqlar qorunur",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/bo.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/bo.json
@@ -107,5 +107,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "ལག་ལེན་འཐབ་ཐུབ་པ།",
   "soa_footer_main.support": "རོགས་རམ་དང་གདུང་སེམས།",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/da.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/da.json
@@ -108,5 +108,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Tilgængelighed",
   "soa_footer_main.support": "Support og Hjælp",
-  "soa_footer_main.allRightReserved": "Eftertryk forbudt"
+  "soa_footer_main.allRightReserved": "Eftertryk forbudt",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/de_DE.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/de_DE.json
@@ -107,5 +107,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Barrierefreiheit",
   "soa_footer_main.support": "Support und Hilfe",
-  "soa_footer_main.allRightReserved": "Alle Rechte vorbehalten"
+  "soa_footer_main.allRightReserved": "Alle Rechte vorbehalten",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/el.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/el.json
@@ -108,5 +108,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Προσβασιμότητα",
   "soa_footer_main.support": "Υποστήριξη και Βοήθεια",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/es_419.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/es_419.json
@@ -107,5 +107,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accesibilidad",
   "soa_footer_main.support": "Soporte y Ayuda",
-  "soa_footer_main.allRightReserved": "Todos los derechos reservados."
+  "soa_footer_main.allRightReserved": "Todos los derechos reservados.",
+  "header.menu.soa.myLearning.label": "Mi aprendizaje"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/es_ES.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/es_ES.json
@@ -108,5 +108,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accesibilidad",
   "soa_footer_main.support": "Soporte y Ayuda",
-  "soa_footer_main.allRightReserved": "Todos los derechos están reservados"
+  "soa_footer_main.allRightReserved": "Todos los derechos están reservados",
+  "header.menu.soa.myLearning.label": "Mi aprendizaje"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/fa.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/fa.json
@@ -107,5 +107,6 @@
   "soa_footer_main.cookies": "کوکی‌ها",
   "soa_footer_main.accessibility": "دسترس‌پذیری",
   "soa_footer_main.support": "پشتیبانی و کمک",
-  "soa_footer_main.allRightReserved": "تمامی حقوق محفوظ است"
+  "soa_footer_main.allRightReserved": "تمامی حقوق محفوظ است",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/fr_CA.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/fr_CA.json
@@ -107,5 +107,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accessibilité",
   "soa_footer_main.support": "Soutien et Aide",
-  "soa_footer_main.allRightReserved": "Tous droits réservés"
+  "soa_footer_main.allRightReserved": "Tous droits réservés",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/he.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/he.json
@@ -108,5 +108,6 @@
   "soa_footer_main.cookies": "עוגיות",
   "soa_footer_main.accessibility": "נגישות",
   "soa_footer_main.support": "תמיכה ועזרה",
-  "soa_footer_main.allRightReserved": "כל הזכויות שמורות"
+  "soa_footer_main.allRightReserved": "כל הזכויות שמורות",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/hi.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/hi.json
@@ -108,5 +108,6 @@
   "soa_footer_main.cookies": "कुकीज़",
   "soa_footer_main.accessibility": "अभिगम्यता",
   "soa_footer_main.support": "सहायता और मदद",
-  "soa_footer_main.allRightReserved": "सभी अधिकार सुरक्षित"
+  "soa_footer_main.allRightReserved": "सभी अधिकार सुरक्षित",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/hu.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/hu.json
@@ -107,5 +107,6 @@
   "soa_footer_main.cookies": "Sütik",
   "soa_footer_main.accessibility": "Akadálymentesség",
   "soa_footer_main.support": "Támogatás és Segítség",
-  "soa_footer_main.allRightReserved": "Minden jog fenntartva"
+  "soa_footer_main.allRightReserved": "Minden jog fenntartva",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/id.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/id.json
@@ -108,5 +108,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Aksesibilitas",
   "soa_footer_main.support": "Dukungan dan Bantuan",
-  "soa_footer_main.allRightReserved": "Seluruh hak cipta"
+  "soa_footer_main.allRightReserved": "Seluruh hak cipta",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/it_IT.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/it_IT.json
@@ -108,5 +108,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "Accessibilità",
   "soa_footer_main.support": "Supporto e Aiuto",
-  "soa_footer_main.allRightReserved": "Tutti i diritti riservati"
+  "soa_footer_main.allRightReserved": "Tutti i diritti riservati",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/ja.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/ja.json
@@ -107,5 +107,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "アクセシビリティ",
   "soa_footer_main.support": "サポートとヘルプ",
-  "soa_footer_main.allRightReserved": "すべての権利を保有"
+  "soa_footer_main.allRightReserved": "すべての権利を保有",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/lv.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/lv.json
@@ -107,5 +107,6 @@
   "soa_footer_main.cookies": "Sīkdatnes",
   "soa_footer_main.accessibility": "Pieejamība",
   "soa_footer_main.support": "Atbalsts un Palīdzība",
-  "soa_footer_main.allRightReserved": "Visas tiesības aizsargātas"
+  "soa_footer_main.allRightReserved": "Visas tiesības aizsargātas",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/pt_BR.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/pt_BR.json
@@ -108,5 +108,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Acessibilidade",
   "soa_footer_main.support": "Suporte e Ajuda",
-  "soa_footer_main.allRightReserved": "Todos os direitos reservados"
+  "soa_footer_main.allRightReserved": "Todos os direitos reservados",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/pt_PT.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/pt_PT.json
@@ -107,5 +107,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Acessibilidade",
   "soa_footer_main.support": "Suporte e Ajuda",
-  "soa_footer_main.allRightReserved": "Todos os direitos reservados"
+  "soa_footer_main.allRightReserved": "Todos os direitos reservados",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/ru.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/ru.json
@@ -108,5 +108,6 @@
   "soa_footer_main.cookies": "Куки",
   "soa_footer_main.accessibility": "Доступность",
   "soa_footer_main.support": "Поддержка и Помощь",
-  "soa_footer_main.allRightReserved": "Все права защищены"
+  "soa_footer_main.allRightReserved": "Все права защищены",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/sv.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/sv.json
@@ -107,5 +107,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Tillgänglighet",
   "soa_footer_main.support": "Support och Hjälp",
-  "soa_footer_main.allRightReserved": "Alla rättigheter förbehållna"
+  "soa_footer_main.allRightReserved": "Alla rättigheter förbehållna",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/sw.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/sw.json
@@ -108,5 +108,6 @@
   "soa_footer_main.cookies": "Vidakuzi",
   "soa_footer_main.accessibility": "Upatikanaji",
   "soa_footer_main.support": "Msaada na Usaidizi",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/te.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/te.json
@@ -108,5 +108,6 @@
   "soa_footer_main.cookies": "కుకీలు",
   "soa_footer_main.accessibility": "అందుబాటు",
   "soa_footer_main.support": "మద్దతు మరియు సహాయం",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/th.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/th.json
@@ -108,5 +108,6 @@
   "soa_footer_main.cookies": "คุกกี้",
   "soa_footer_main.accessibility": "การเข้าถึง",
   "soa_footer_main.support": "การสนับสนุนและความช่วยเหลือ",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/tr_TR.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/tr_TR.json
@@ -107,5 +107,6 @@
   "soa_footer_main.cookies": "Çerezler",
   "soa_footer_main.accessibility": "Erişilebilirlik",
   "soa_footer_main.support": "Destek ve Yardım",
-  "soa_footer_main.allRightReserved": "Tüm hakları saklıdır"
+  "soa_footer_main.allRightReserved": "Tüm hakları saklıdır",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/uk.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/uk.json
@@ -108,5 +108,6 @@
   "soa_footer_main.cookies": "Файли cookie",
   "soa_footer_main.accessibility": "Доступність",
   "soa_footer_main.support": "Підтримка та Допомога",
-  "soa_footer_main.allRightReserved": "Всі права захищено"
+  "soa_footer_main.allRightReserved": "Всі права захищено",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/uz.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/uz.json
@@ -107,5 +107,6 @@
   "soa_footer_main.cookies": "Kukilar",
   "soa_footer_main.accessibility": "Imkoniyat",
   "soa_footer_main.support": "Qo'llab-quvvatlash va Yordam",
-  "soa_footer_main.allRightReserved": "Barcha huquqlar himoyalangan"
+  "soa_footer_main.allRightReserved": "Barcha huquqlar himoyalangan",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/vi.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/vi.json
@@ -107,5 +107,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "Khả năng tiếp cận",
   "soa_footer_main.support": "Hỗ trợ và Trợ giúp",
-  "soa_footer_main.allRightReserved": "Đã đăng ký Bản quyền"
+  "soa_footer_main.allRightReserved": "Đã đăng ký Bản quyền",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/zh_CN.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/zh_CN.json
@@ -108,5 +108,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "无障碍",
   "soa_footer_main.support": "支持与帮助",
-  "soa_footer_main.allRightReserved": "保留所有权利"
+  "soa_footer_main.allRightReserved": "保留所有权利",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/messages/zh_HK.json
+++ b/translations/frontend-app-ora-grading/src/i18n/messages/zh_HK.json
@@ -107,5 +107,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "無障礙",
   "soa_footer_main.support": "支援與幫助",
-  "soa_footer_main.allRightReserved": "版權所有"
+  "soa_footer_main.allRightReserved": "版權所有",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-ora-grading/src/i18n/transifex_input.json
+++ b/translations/frontend-app-ora-grading/src/i18n/transifex_input.json
@@ -107,5 +107,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accessibility",
   "soa_footer_main.support": "Support and Help",
-  "soa_footer_main.allRightReserved": "All rights reserved"
+  "soa_footer_main.allRightReserved": "All rights reserved",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/af_ZA.json
+++ b/translations/frontend-app-profile/src/i18n/messages/af_ZA.json
@@ -61,5 +61,6 @@
   "soa_footer_main.cookies": "Koekies",
   "soa_footer_main.accessibility": "Toeganklikheid",
   "soa_footer_main.support": "Ondersteuning en Hulp",
-  "soa_footer_main.allRightReserved": "Alle regte voorbehou"
+  "soa_footer_main.allRightReserved": "Alle regte voorbehou",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/ar.json
+++ b/translations/frontend-app-profile/src/i18n/messages/ar.json
@@ -61,5 +61,6 @@
   "soa_footer_main.cookies": "ملفات تعريف الارتباط",
   "soa_footer_main.accessibility": "إمكانية الوصول",
   "soa_footer_main.support": "الدعم والمساعدة",
-  "soa_footer_main.allRightReserved": "جميع الحقوق محفوظة"
+  "soa_footer_main.allRightReserved": "جميع الحقوق محفوظة",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/az.json
+++ b/translations/frontend-app-profile/src/i18n/messages/az.json
@@ -61,5 +61,6 @@
   "soa_footer_main.cookies": "Kukilər",
   "soa_footer_main.accessibility": "Əlçatanlıq",
   "soa_footer_main.support": "Dəstək və Yardım",
-  "soa_footer_main.allRightReserved": "Bütün hüquqlar qorunur"
+  "soa_footer_main.allRightReserved": "Bütün hüquqlar qorunur",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/bo.json
+++ b/translations/frontend-app-profile/src/i18n/messages/bo.json
@@ -61,5 +61,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "ལག་ལེན་འཐབ་ཐུབ་པ།",
   "soa_footer_main.support": "རོགས་རམ་དང་གདུང་སེམས།",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/da.json
+++ b/translations/frontend-app-profile/src/i18n/messages/da.json
@@ -60,5 +60,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Tilgængelighed",
   "soa_footer_main.support": "Support og Hjælp",
-  "soa_footer_main.allRightReserved": "Eftertryk forbudt"
+  "soa_footer_main.allRightReserved": "Eftertryk forbudt",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/de.json
+++ b/translations/frontend-app-profile/src/i18n/messages/de.json
@@ -60,5 +60,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Barrierefreiheit",
   "soa_footer_main.support": "Support und Hilfe",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/de_DE.json
+++ b/translations/frontend-app-profile/src/i18n/messages/de_DE.json
@@ -61,5 +61,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Barrierefreiheit",
   "soa_footer_main.support": "Support und Hilfe",
-  "soa_footer_main.allRightReserved": "Alle Rechte vorbehalten"
+  "soa_footer_main.allRightReserved": "Alle Rechte vorbehalten",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/el.json
+++ b/translations/frontend-app-profile/src/i18n/messages/el.json
@@ -60,5 +60,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Προσβασιμότητα",
   "soa_footer_main.support": "Υποστήριξη και Βοήθεια",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/es_419.json
+++ b/translations/frontend-app-profile/src/i18n/messages/es_419.json
@@ -61,5 +61,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accesibilidad",
   "soa_footer_main.support": "Soporte y Ayuda",
-  "soa_footer_main.allRightReserved": "Todos los derechos reservados."
+  "soa_footer_main.allRightReserved": "Todos los derechos reservados.",
+  "header.menu.soa.myLearning.label": "Mi aprendizaje"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/es_ES.json
+++ b/translations/frontend-app-profile/src/i18n/messages/es_ES.json
@@ -61,5 +61,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accesibilidad",
   "soa_footer_main.support": "Soporte y Ayuda",
-  "soa_footer_main.allRightReserved": "Todos los derechos están reservados"
+  "soa_footer_main.allRightReserved": "Todos los derechos están reservados",
+  "header.menu.soa.myLearning.label": "Mi aprendizaje"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/fa.json
+++ b/translations/frontend-app-profile/src/i18n/messages/fa.json
@@ -61,5 +61,6 @@
   "soa_footer_main.cookies": "کوکی‌ها",
   "soa_footer_main.accessibility": "دسترس‌پذیری",
   "soa_footer_main.support": "پشتیبانی و کمک",
-  "soa_footer_main.allRightReserved": "تمامی حقوق محفوظ است"
+  "soa_footer_main.allRightReserved": "تمامی حقوق محفوظ است",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/fr_CA.json
+++ b/translations/frontend-app-profile/src/i18n/messages/fr_CA.json
@@ -61,5 +61,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accessibilité",
   "soa_footer_main.support": "Soutien et Aide",
-  "soa_footer_main.allRightReserved": "Tous droits réservés"
+  "soa_footer_main.allRightReserved": "Tous droits réservés",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/he.json
+++ b/translations/frontend-app-profile/src/i18n/messages/he.json
@@ -60,5 +60,6 @@
   "soa_footer_main.cookies": "עוגיות",
   "soa_footer_main.accessibility": "נגישות",
   "soa_footer_main.support": "תמיכה ועזרה",
-  "soa_footer_main.allRightReserved": "כל הזכויות שמורות"
+  "soa_footer_main.allRightReserved": "כל הזכויות שמורות",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/hi.json
+++ b/translations/frontend-app-profile/src/i18n/messages/hi.json
@@ -61,5 +61,6 @@
   "soa_footer_main.cookies": "कुकीज़",
   "soa_footer_main.accessibility": "अभिगम्यता",
   "soa_footer_main.support": "सहायता और मदद",
-  "soa_footer_main.allRightReserved": "सभी अधिकार सुरक्षित"
+  "soa_footer_main.allRightReserved": "सभी अधिकार सुरक्षित",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/hu.json
+++ b/translations/frontend-app-profile/src/i18n/messages/hu.json
@@ -61,5 +61,6 @@
   "soa_footer_main.cookies": "Sütik",
   "soa_footer_main.accessibility": "Akadálymentesség",
   "soa_footer_main.support": "Támogatás és Segítség",
-  "soa_footer_main.allRightReserved": "Minden jog fenntartva"
+  "soa_footer_main.allRightReserved": "Minden jog fenntartva",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/id.json
+++ b/translations/frontend-app-profile/src/i18n/messages/id.json
@@ -60,5 +60,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Aksesibilitas",
   "soa_footer_main.support": "Dukungan dan Bantuan",
-  "soa_footer_main.allRightReserved": "Seluruh hak cipta"
+  "soa_footer_main.allRightReserved": "Seluruh hak cipta",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/it_IT.json
+++ b/translations/frontend-app-profile/src/i18n/messages/it_IT.json
@@ -61,5 +61,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "Accessibilità",
   "soa_footer_main.support": "Supporto e Aiuto",
-  "soa_footer_main.allRightReserved": "Tutti i diritti riservati"
+  "soa_footer_main.allRightReserved": "Tutti i diritti riservati",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/ja.json
+++ b/translations/frontend-app-profile/src/i18n/messages/ja.json
@@ -61,5 +61,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "アクセシビリティ",
   "soa_footer_main.support": "サポートとヘルプ",
-  "soa_footer_main.allRightReserved": "すべての権利を保有"
+  "soa_footer_main.allRightReserved": "すべての権利を保有",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/kk.json
+++ b/translations/frontend-app-profile/src/i18n/messages/kk.json
@@ -55,5 +55,6 @@
   "profile.formcontrols.button.saved": "",
   "profile.visibility.who.just.me": "",
   "profile.visibility.who.everyone": "",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/lv.json
+++ b/translations/frontend-app-profile/src/i18n/messages/lv.json
@@ -61,5 +61,6 @@
   "soa_footer_main.cookies": "Sīkdatnes",
   "soa_footer_main.accessibility": "Pieejamība",
   "soa_footer_main.support": "Atbalsts un Palīdzība",
-  "soa_footer_main.allRightReserved": "Visas tiesības aizsargātas"
+  "soa_footer_main.allRightReserved": "Visas tiesības aizsargātas",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/pt_BR.json
+++ b/translations/frontend-app-profile/src/i18n/messages/pt_BR.json
@@ -60,5 +60,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Acessibilidade",
   "soa_footer_main.support": "Suporte e Ajuda",
-  "soa_footer_main.allRightReserved": "Todos os direitos reservados"
+  "soa_footer_main.allRightReserved": "Todos os direitos reservados",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/pt_PT.json
+++ b/translations/frontend-app-profile/src/i18n/messages/pt_PT.json
@@ -61,5 +61,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Acessibilidade",
   "soa_footer_main.support": "Suporte e Ajuda",
-  "soa_footer_main.allRightReserved": "Todos os direitos reservados"
+  "soa_footer_main.allRightReserved": "Todos os direitos reservados",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/ro.json
+++ b/translations/frontend-app-profile/src/i18n/messages/ro.json
@@ -61,5 +61,6 @@
   "soa_footer_main.cookies": "Cookie-uri",
   "soa_footer_main.accessibility": "Accesibilitate",
   "soa_footer_main.support": "Suport și Ajutor",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/ru.json
+++ b/translations/frontend-app-profile/src/i18n/messages/ru.json
@@ -60,5 +60,6 @@
   "soa_footer_main.cookies": "Куки",
   "soa_footer_main.accessibility": "Доступность",
   "soa_footer_main.support": "Поддержка и Помощь",
-  "soa_footer_main.allRightReserved": "Все права защищены"
+  "soa_footer_main.allRightReserved": "Все права защищены",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/sv.json
+++ b/translations/frontend-app-profile/src/i18n/messages/sv.json
@@ -61,5 +61,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Tillgänglighet",
   "soa_footer_main.support": "Support och Hjälp",
-  "soa_footer_main.allRightReserved": "Alla rättigheter förbehållna"
+  "soa_footer_main.allRightReserved": "Alla rättigheter förbehållna",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/sw.json
+++ b/translations/frontend-app-profile/src/i18n/messages/sw.json
@@ -60,5 +60,6 @@
   "soa_footer_main.cookies": "Vidakuzi",
   "soa_footer_main.accessibility": "Upatikanaji",
   "soa_footer_main.support": "Msaada na Usaidizi",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/te.json
+++ b/translations/frontend-app-profile/src/i18n/messages/te.json
@@ -60,5 +60,6 @@
   "soa_footer_main.cookies": "కుకీలు",
   "soa_footer_main.accessibility": "అందుబాటు",
   "soa_footer_main.support": "మద్దతు మరియు సహాయం",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/th.json
+++ b/translations/frontend-app-profile/src/i18n/messages/th.json
@@ -60,5 +60,6 @@
   "soa_footer_main.cookies": "คุกกี้",
   "soa_footer_main.accessibility": "การเข้าถึง",
   "soa_footer_main.support": "การสนับสนุนและความช่วยเหลือ",
-  "soa_footer_main.allRightReserved": ""
+  "soa_footer_main.allRightReserved": "",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/tr_TR.json
+++ b/translations/frontend-app-profile/src/i18n/messages/tr_TR.json
@@ -61,5 +61,6 @@
   "soa_footer_main.cookies": "Çerezler",
   "soa_footer_main.accessibility": "Erişilebilirlik",
   "soa_footer_main.support": "Destek ve Yardım",
-  "soa_footer_main.allRightReserved": "Tüm hakları saklıdır"
+  "soa_footer_main.allRightReserved": "Tüm hakları saklıdır",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/uk.json
+++ b/translations/frontend-app-profile/src/i18n/messages/uk.json
@@ -61,5 +61,6 @@
   "soa_footer_main.cookies": "Файли cookie",
   "soa_footer_main.accessibility": "Доступність",
   "soa_footer_main.support": "Підтримка та Допомога",
-  "soa_footer_main.allRightReserved": "Всі права захищено"
+  "soa_footer_main.allRightReserved": "Всі права захищено",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/uz.json
+++ b/translations/frontend-app-profile/src/i18n/messages/uz.json
@@ -61,5 +61,6 @@
   "soa_footer_main.cookies": "Kukilar",
   "soa_footer_main.accessibility": "Imkoniyat",
   "soa_footer_main.support": "Qo'llab-quvvatlash va Yordam",
-  "soa_footer_main.allRightReserved": "Barcha huquqlar himoyalangan"
+  "soa_footer_main.allRightReserved": "Barcha huquqlar himoyalangan",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/vi.json
+++ b/translations/frontend-app-profile/src/i18n/messages/vi.json
@@ -61,5 +61,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "Khả năng tiếp cận",
   "soa_footer_main.support": "Hỗ trợ và Trợ giúp",
-  "soa_footer_main.allRightReserved": "Đã đăng ký Bản quyền"
+  "soa_footer_main.allRightReserved": "Đã đăng ký Bản quyền",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/zh_CN.json
+++ b/translations/frontend-app-profile/src/i18n/messages/zh_CN.json
@@ -61,5 +61,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "无障碍",
   "soa_footer_main.support": "支持与帮助",
-  "soa_footer_main.allRightReserved": "保留所有权利"
+  "soa_footer_main.allRightReserved": "保留所有权利",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/messages/zh_HK.json
+++ b/translations/frontend-app-profile/src/i18n/messages/zh_HK.json
@@ -61,5 +61,6 @@
   "soa_footer_main.cookies": "Cookie",
   "soa_footer_main.accessibility": "無障礙",
   "soa_footer_main.support": "支援與幫助",
-  "soa_footer_main.allRightReserved": "版權所有"
+  "soa_footer_main.allRightReserved": "版權所有",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-app-profile/src/i18n/transifex_input.json
+++ b/translations/frontend-app-profile/src/i18n/transifex_input.json
@@ -61,5 +61,6 @@
   "soa_footer_main.cookies": "Cookies",
   "soa_footer_main.accessibility": "Accessibility",
   "soa_footer_main.support": "Support and Help",
-  "soa_footer_main.allRightReserved": "All rights reserved"
+  "soa_footer_main.allRightReserved": "All rights reserved",
+  "header.menu.soa.myLearning.label": "My Learning"
 }

--- a/translations/frontend-component-header/src/i18n/messages/af_ZA.json
+++ b/translations/frontend-component-header/src/i18n/messages/af_ZA.json
@@ -37,5 +37,6 @@
   "header.label.search.nav": "Soek inhoud",
   "header.menu.soa.blog.label": "Blog",
   "header.menu.soa.whoWeAre.label": "Wie ons is",
-  "header.menu.soa.search.label": "Soek"
+  "header.menu.soa.search.label": "Soek",
+  "header.menu.soa.myLearning.label": "My leer"
 }

--- a/translations/frontend-component-header/src/i18n/messages/ar.json
+++ b/translations/frontend-component-header/src/i18n/messages/ar.json
@@ -37,5 +37,6 @@
   "header.label.search.nav": "ابحَث في المُحتَوى\n",
   "header.menu.soa.blog.label": "مدونة",
   "header.menu.soa.whoWeAre.label": "من نحن",
-  "header.menu.soa.search.label": "بحث"
+  "header.menu.soa.search.label": "بحث",
+  "header.menu.soa.myLearning.label": "تعلّمي"
 }

--- a/translations/frontend-component-header/src/i18n/messages/az.json
+++ b/translations/frontend-component-header/src/i18n/messages/az.json
@@ -37,5 +37,6 @@
   "header.label.search.nav": "Axtarış məzmunu",
   "header.menu.soa.blog.label": "Bloq",
   "header.menu.soa.whoWeAre.label": "Biz kimik",
-  "header.menu.soa.search.label": "Axtarış"
+  "header.menu.soa.search.label": "Axtarış",
+  "header.menu.soa.myLearning.label": "Mənim öyrənməm"
 }

--- a/translations/frontend-component-header/src/i18n/messages/bo.json
+++ b/translations/frontend-component-header/src/i18n/messages/bo.json
@@ -37,5 +37,6 @@
   "header.label.search.nav": "ནང་དོན་འཚོལ་བཤེར།",
   "header.menu.soa.blog.label": "ཟིན་བྲིས།",
   "header.menu.soa.whoWeAre.label": "ང་ཚོ་སུ་ཡིན།",
-  "header.menu.soa.search.label": "འཚོལ།"
+  "header.menu.soa.search.label": "འཚོལ།",
+  "header.menu.soa.myLearning.label": "ངའི་སློབ་སྦྱོང་།"
 }

--- a/translations/frontend-component-header/src/i18n/messages/da.json
+++ b/translations/frontend-component-header/src/i18n/messages/da.json
@@ -35,5 +35,6 @@
   "header.label.courseOutline": "Tilbage til kursusoversigt i Studio",
   "header.menu.soa.blog.label": "Blog",
   "header.menu.soa.whoWeAre.label": "Hvem er vi",
-  "header.menu.soa.search.label": "Søg"
+  "header.menu.soa.search.label": "Søg",
+  "header.menu.soa.myLearning.label": "Min læring"
 }

--- a/translations/frontend-component-header/src/i18n/messages/de.json
+++ b/translations/frontend-component-header/src/i18n/messages/de.json
@@ -55,5 +55,6 @@
   "header.label.courseOutline": "Back to course outline in Studio",
   "header.menu.soa.blog.label": "Blog",
   "header.menu.soa.whoWeAre.label": "Wer wir sind",
-  "header.menu.soa.search.label": "Suche"
+  "header.menu.soa.search.label": "Suche",
+  "header.menu.soa.myLearning.label": "Mein Lernen"
 }

--- a/translations/frontend-component-header/src/i18n/messages/de_DE.json
+++ b/translations/frontend-component-header/src/i18n/messages/de_DE.json
@@ -37,5 +37,6 @@
   "header.label.search.nav": "Inhalte durchsuchen",
   "header.menu.soa.blog.label": "Blog",
   "header.menu.soa.whoWeAre.label": "Wer wir sind",
-  "header.menu.soa.search.label": "Suche"
+  "header.menu.soa.search.label": "Suche",
+  "header.menu.soa.myLearning.label": "Mein Lernen"
 }

--- a/translations/frontend-component-header/src/i18n/messages/el.json
+++ b/translations/frontend-component-header/src/i18n/messages/el.json
@@ -35,5 +35,6 @@
   "header.label.courseOutline": "Επιστροφή στο σχεδιάγραμμα μαθημάτων στο Στούντιο",
   "header.menu.soa.blog.label": "Ιστολόγιο",
   "header.menu.soa.whoWeAre.label": "Ποιοι είμαστε",
-  "header.menu.soa.search.label": "Αναζήτηση"
+  "header.menu.soa.search.label": "Αναζήτηση",
+  "header.menu.soa.myLearning.label": "Η μάθησή μου"
 }

--- a/translations/frontend-component-header/src/i18n/messages/es_419.json
+++ b/translations/frontend-component-header/src/i18n/messages/es_419.json
@@ -37,5 +37,6 @@
   "header.label.search.nav": "Buscar contenido",
   "header.menu.soa.blog.label": "Blog",
   "header.menu.soa.whoWeAre.label": "Quiénes somos",
-  "header.menu.soa.search.label": "Buscar"
+  "header.menu.soa.search.label": "Buscar",
+  "header.menu.soa.myLearning.label": "Mi aprendizaje"
 }

--- a/translations/frontend-component-header/src/i18n/messages/es_ES.json
+++ b/translations/frontend-component-header/src/i18n/messages/es_ES.json
@@ -37,5 +37,6 @@
   "header.label.search.nav": "",
   "header.menu.soa.blog.label": "Blog",
   "header.menu.soa.whoWeAre.label": "Quiénes somos",
-  "header.menu.soa.search.label": "Buscar"
+  "header.menu.soa.search.label": "Buscar",
+  "header.menu.soa.myLearning.label": "Mi aprendizaje"
 }

--- a/translations/frontend-component-header/src/i18n/messages/fa.json
+++ b/translations/frontend-component-header/src/i18n/messages/fa.json
@@ -37,5 +37,6 @@
   "header.label.search.nav": "جستجوی محتوا",
   "header.menu.soa.blog.label": "وبلاگ",
   "header.menu.soa.whoWeAre.label": "ما که هستیم",
-  "header.menu.soa.search.label": "جستجو"
+  "header.menu.soa.search.label": "جستجو",
+  "header.menu.soa.myLearning.label": "یادگیری من"
 }

--- a/translations/frontend-component-header/src/i18n/messages/fr_CA.json
+++ b/translations/frontend-component-header/src/i18n/messages/fr_CA.json
@@ -37,5 +37,6 @@
   "header.label.search.nav": "Rechercher du contenu",
   "header.menu.soa.blog.label": "Blogue",
   "header.menu.soa.whoWeAre.label": "Qui nous sommes",
-  "header.menu.soa.search.label": "Rechercher"
+  "header.menu.soa.search.label": "Rechercher",
+  "header.menu.soa.myLearning.label": "Mon apprentissage"
 }

--- a/translations/frontend-component-header/src/i18n/messages/he.json
+++ b/translations/frontend-component-header/src/i18n/messages/he.json
@@ -35,5 +35,6 @@
   "header.label.courseOutline": "חזרה למתווה הקורס בסטודיו",
   "header.menu.soa.blog.label": "בלוג",
   "header.menu.soa.whoWeAre.label": "מי אנחנו",
-  "header.menu.soa.search.label": "חיפוש"
+  "header.menu.soa.search.label": "חיפוש",
+  "header.menu.soa.myLearning.label": "הלמידה שלי"
 }

--- a/translations/frontend-component-header/src/i18n/messages/hi.json
+++ b/translations/frontend-component-header/src/i18n/messages/hi.json
@@ -37,5 +37,6 @@
   "header.label.search.nav": "खोज सामग्री",
   "header.menu.soa.blog.label": "ब्लॉग",
   "header.menu.soa.whoWeAre.label": "हम कौन हैं",
-  "header.menu.soa.search.label": "खोजें"
+  "header.menu.soa.search.label": "खोजें",
+  "header.menu.soa.myLearning.label": "मेरी शिक्षा"
 }

--- a/translations/frontend-component-header/src/i18n/messages/hu.json
+++ b/translations/frontend-component-header/src/i18n/messages/hu.json
@@ -37,5 +37,6 @@
   "header.label.search.nav": "Tartalom keresése",
   "header.menu.soa.blog.label": "Blog",
   "header.menu.soa.whoWeAre.label": "Kik vagyunk",
-  "header.menu.soa.search.label": "Keresés"
+  "header.menu.soa.search.label": "Keresés",
+  "header.menu.soa.myLearning.label": "Tanulásaim"
 }

--- a/translations/frontend-component-header/src/i18n/messages/id.json
+++ b/translations/frontend-component-header/src/i18n/messages/id.json
@@ -35,5 +35,6 @@
   "header.label.courseOutline": "Back to course outline in Studio",
   "header.menu.soa.blog.label": "Blog",
   "header.menu.soa.whoWeAre.label": "Siapa kami",
-  "header.menu.soa.search.label": "Cari"
+  "header.menu.soa.search.label": "Cari",
+  "header.menu.soa.myLearning.label": "Pembelajaran Saya"
 }

--- a/translations/frontend-component-header/src/i18n/messages/it_IT.json
+++ b/translations/frontend-component-header/src/i18n/messages/it_IT.json
@@ -37,5 +37,6 @@
   "header.label.search.nav": "",
   "header.menu.soa.blog.label": "Blog",
   "header.menu.soa.whoWeAre.label": "Chi siamo",
-  "header.menu.soa.search.label": "Cerca"
+  "header.menu.soa.search.label": "Cerca",
+  "header.menu.soa.myLearning.label": "Il mio apprendimento"
 }

--- a/translations/frontend-component-header/src/i18n/messages/ja.json
+++ b/translations/frontend-component-header/src/i18n/messages/ja.json
@@ -37,5 +37,6 @@
   "header.label.search.nav": "コンテンツを検索",
   "header.menu.soa.blog.label": "ブログ",
   "header.menu.soa.whoWeAre.label": "私たちについて",
-  "header.menu.soa.search.label": "検索"
+  "header.menu.soa.search.label": "検索",
+  "header.menu.soa.myLearning.label": "マイラーニング"
 }

--- a/translations/frontend-component-header/src/i18n/messages/lv.json
+++ b/translations/frontend-component-header/src/i18n/messages/lv.json
@@ -37,5 +37,6 @@
   "header.label.search.nav": "Meklēt saturu",
   "header.menu.soa.blog.label": "E-tinklaroštis",
   "header.menu.soa.whoWeAre.label": "Kas mēs esam",
-  "header.menu.soa.search.label": "Meklēt"
+  "header.menu.soa.search.label": "Meklēt",
+  "header.menu.soa.myLearning.label": "Mana mācīšanās"
 }

--- a/translations/frontend-component-header/src/i18n/messages/pt_BR.json
+++ b/translations/frontend-component-header/src/i18n/messages/pt_BR.json
@@ -35,5 +35,6 @@
   "header.label.courseOutline": "Visualizar resumo do curso no Studio",
   "header.menu.soa.blog.label": "Blog",
   "header.menu.soa.whoWeAre.label": "Quem somos",
-  "header.menu.soa.search.label": "Buscar"
+  "header.menu.soa.search.label": "Buscar",
+  "header.menu.soa.myLearning.label": "Meu aprendizado"
 }

--- a/translations/frontend-component-header/src/i18n/messages/pt_PT.json
+++ b/translations/frontend-component-header/src/i18n/messages/pt_PT.json
@@ -37,5 +37,6 @@
   "header.label.search.nav": "Pesquisar conteúdo",
   "header.menu.soa.blog.label": "Blog",
   "header.menu.soa.whoWeAre.label": "Quem somos",
-  "header.menu.soa.search.label": "Procurar"
+  "header.menu.soa.search.label": "Procurar",
+  "header.menu.soa.myLearning.label": "A minha aprendizagem"
 }

--- a/translations/frontend-component-header/src/i18n/messages/ro.json
+++ b/translations/frontend-component-header/src/i18n/messages/ro.json
@@ -37,5 +37,6 @@
   "header.label.search.nav": "",
   "header.menu.soa.blog.label": "Blog",
   "header.menu.soa.whoWeAre.label": "Cine suntem",
-  "header.menu.soa.search.label": "Căutare"
+  "header.menu.soa.search.label": "Căutare",
+  "header.menu.soa.myLearning.label": "Învățarea mea"
 }

--- a/translations/frontend-component-header/src/i18n/messages/ru.json
+++ b/translations/frontend-component-header/src/i18n/messages/ru.json
@@ -35,5 +35,6 @@
   "header.label.courseOutline": "Вернуться к плану курса в Студии",
   "header.menu.soa.blog.label": "Блог",
   "header.menu.soa.whoWeAre.label": "Кто мы",
-  "header.menu.soa.search.label": "Поиск"
+  "header.menu.soa.search.label": "Поиск",
+  "header.menu.soa.myLearning.label": "Моё обучение"
 }

--- a/translations/frontend-component-header/src/i18n/messages/sv.json
+++ b/translations/frontend-component-header/src/i18n/messages/sv.json
@@ -37,5 +37,6 @@
   "header.label.search.nav": "Sök innehåll",
   "header.menu.soa.blog.label": "Blogg",
   "header.menu.soa.whoWeAre.label": "Vilka vi är",
-  "header.menu.soa.search.label": "Sök"
+  "header.menu.soa.search.label": "Sök",
+  "header.menu.soa.myLearning.label": "Mitt lärande"
 }

--- a/translations/frontend-component-header/src/i18n/messages/sw.json
+++ b/translations/frontend-component-header/src/i18n/messages/sw.json
@@ -35,5 +35,6 @@
   "header.label.courseOutline": "Rudi kwenye muhtasari wa kozi katika Studio",
   "header.menu.soa.blog.label": "Blogu",
   "header.menu.soa.whoWeAre.label": "Sisi ni nani",
-  "header.menu.soa.search.label": "Tafuta"
+  "header.menu.soa.search.label": "Tafuta",
+  "header.menu.soa.myLearning.label": "Mafunzo yangu"
 }

--- a/translations/frontend-component-header/src/i18n/messages/te.json
+++ b/translations/frontend-component-header/src/i18n/messages/te.json
@@ -35,5 +35,6 @@
   "header.label.courseOutline": "స్టూడియోలోని కోర్సు అవుట్‌లైన్‌కి తిరిగి వెళ్ళు",
   "header.menu.soa.blog.label": "బ్లాగ్",
   "header.menu.soa.whoWeAre.label": "మేము ఎవరు",
-  "header.menu.soa.search.label": "వెతకండి"
+  "header.menu.soa.search.label": "వెతకండి",
+  "header.menu.soa.myLearning.label": "నా అభ్యసనం"
 }

--- a/translations/frontend-component-header/src/i18n/messages/th.json
+++ b/translations/frontend-component-header/src/i18n/messages/th.json
@@ -35,5 +35,6 @@
   "header.label.courseOutline": "กลับไปที่โครงร่างหลักสูตรใน Studio",
   "header.menu.soa.blog.label": "บล็อก",
   "header.menu.soa.whoWeAre.label": "เราเป็นใคร",
-  "header.menu.soa.search.label": "ค้นหา"
+  "header.menu.soa.search.label": "ค้นหา",
+  "header.menu.soa.myLearning.label": "การเรียนรู้ของฉัน"
 }

--- a/translations/frontend-component-header/src/i18n/messages/tr_TR.json
+++ b/translations/frontend-component-header/src/i18n/messages/tr_TR.json
@@ -37,5 +37,6 @@
   "header.label.search.nav": "İçerik ara",
   "header.menu.soa.blog.label": "Blog",
   "header.menu.soa.whoWeAre.label": "Biz kimiz",
-  "header.menu.soa.search.label": "Ara"
+  "header.menu.soa.search.label": "Ara",
+  "header.menu.soa.myLearning.label": "Öğrenimim"
 }

--- a/translations/frontend-component-header/src/i18n/messages/uk.json
+++ b/translations/frontend-component-header/src/i18n/messages/uk.json
@@ -37,5 +37,6 @@
   "header.label.search.nav": "",
   "header.menu.soa.blog.label": "Блог",
   "header.menu.soa.whoWeAre.label": "Хто ми є",
-  "header.menu.soa.search.label": "Пошук"
+  "header.menu.soa.search.label": "Пошук",
+  "header.menu.soa.myLearning.label": "Моє навчання"
 }

--- a/translations/frontend-component-header/src/i18n/messages/uz.json
+++ b/translations/frontend-component-header/src/i18n/messages/uz.json
@@ -37,5 +37,6 @@
   "header.label.search.nav": "Kontentni qidirish",
   "header.menu.soa.blog.label": "Blog",
   "header.menu.soa.whoWeAre.label": "Biz kimmiz",
-  "header.menu.soa.search.label": "Qidirish"
+  "header.menu.soa.search.label": "Qidirish",
+  "header.menu.soa.myLearning.label": "Mening o'rganishim"
 }

--- a/translations/frontend-component-header/src/i18n/messages/vi.json
+++ b/translations/frontend-component-header/src/i18n/messages/vi.json
@@ -37,5 +37,6 @@
   "header.label.search.nav": "Tìm kiếm nội dung",
   "header.menu.soa.blog.label": "Blog",
   "header.menu.soa.whoWeAre.label": "Chúng tôi là ai",
-  "header.menu.soa.search.label": "Tìm kiếm"
+  "header.menu.soa.search.label": "Tìm kiếm",
+  "header.menu.soa.myLearning.label": "Học tập của tôi"
 }

--- a/translations/frontend-component-header/src/i18n/messages/zh_CN.json
+++ b/translations/frontend-component-header/src/i18n/messages/zh_CN.json
@@ -37,5 +37,6 @@
   "header.label.search.nav": "",
   "header.menu.soa.blog.label": "博客",
   "header.menu.soa.whoWeAre.label": "关于我们",
-  "header.menu.soa.search.label": "搜索"
+  "header.menu.soa.search.label": "搜索",
+  "header.menu.soa.myLearning.label": "我的学习"
 }

--- a/translations/frontend-component-header/src/i18n/messages/zh_HK.json
+++ b/translations/frontend-component-header/src/i18n/messages/zh_HK.json
@@ -37,5 +37,6 @@
   "header.label.search.nav": "搜尋內容",
   "header.menu.soa.blog.label": "網誌",
   "header.menu.soa.whoWeAre.label": "關於我們",
-  "header.menu.soa.search.label": "搜尋"
+  "header.menu.soa.search.label": "搜尋",
+  "header.menu.soa.myLearning.label": "我的學習"
 }

--- a/translations/frontend-component-header/src/i18n/transifex_input.json
+++ b/translations/frontend-component-header/src/i18n/transifex_input.json
@@ -37,5 +37,6 @@
   "header.label.search.nav": "Search content",
   "header.menu.soa.blog.label": "Blog",
   "header.menu.soa.whoWeAre.label": "Who we are",
-  "header.menu.soa.search.label": "Search"
+  "header.menu.soa.search.label": "Search",
+  "header.menu.soa.myLearning.label": "My Learning"
 }


### PR DESCRIPTION
This pull request adds translations for the "My Learning" menu label across multiple languages in both backend (`django.po`) and frontend (`i18n/messages/*.json`) translation files. The changes ensure that the "My Learning" label is available and appropriately localized in the user interface for a wide range of supported languages.

**Internationalization updates:**

* Added the "My Learning" label (`header.menu.soa.myLearning.label`) to frontend translation files for various languages, including Afrikaans, Arabic, Azerbaijani, Tibetan, Danish, German, Greek, Latin American Spanish, Spanish (Spain), Persian, Canadian French, Hebrew, Hindi, Hungarian, Indonesian, Italian, Japanese, and more. [[1]](diffhunk://#diff-5e8b6a3862dbd3ed0925694d9b1d7f3a16ef9e4b5696204f0d1be84af2a132e2L339-R340) [[2]](diffhunk://#diff-c90f047c48d276fed467e29b0070937b4dd9fb6daf136d9e3e97a79cc07178bcL339-R340) [[3]](diffhunk://#diff-9a24f3c89286c08cbe7091a8ed31c6a0c5b06dfe3a2a1d935c7f6775d1eaa859L332-R333) [[4]](diffhunk://#diff-ed8ef993d06991043c395ab4a96b21e760f10a7b56d6d70a5bb7dde47e62861dL339-R340) [[5]](diffhunk://#diff-ae78673344be8970a16092089cede7f6581eb37daf90d9e1fe7c97e6827fa6a2L364-R365) [[6]](diffhunk://#diff-d8ba699881bf32992928248cce63cc408a8fe8af4390ce42be83981134f9d42aL360-R361) [[7]](diffhunk://#diff-f1d22b8195b8b7faf95c56039c48af83c1fc4d83ff5ab414bbb140d8e24d0d56L339-R340) [[8]](diffhunk://#diff-59365c1c553bf89fd58f50da3493a97ef6fa5f4e1f94b172278d148c1b393f64L339-R340) [[9]](diffhunk://#diff-d3cdcb04dc76d01dd085d7c79e396ade37d587ceeb5531259a42845c90a0d221L339-R340) [[10]](diffhunk://#diff-89d97e38ef7711ba158d50b4b8ec695a10aa8e0f71bdd88be2ef7e0ed0ceac81L339-R340) [[11]](diffhunk://#diff-913bd4f00fc25cb7716a8794dc86683fe150f098961cdc5454641abdfa4c8c1aL339-R340) [[12]](diffhunk://#diff-29d1729aab97869d7175b579a9145c9f3c6d3f0a353d2eb518f26382ef0e883cL339-R340) [[13]](diffhunk://#diff-d586e643ac2d004860ab7a71d8cdb2b3dd2322afccf74713e6eee39fe47d8d9fL364-R365) [[14]](diffhunk://#diff-8ba85f26499adb3096183357e8452fdad098ec7864f9d3961003265e908ecf12L339-R340) [[15]](diffhunk://#diff-c184d7f155fa4457372dc9d0cfa06062d4d8d6fbd57c9a6d0e5bc9839a3cd73fL339-R340) [[16]](diffhunk://#diff-7959a061f318ad0aff83e4cea6abc99ba7c8ae79137d71733ac09c4fc4f4433dL364-R365) [[17]](diffhunk://#diff-fb7b299a9f428f3a1caffaa80b5fc9990eb1cab468d88e016c809bfc9bbff015L339-R340) [[18]](diffhunk://#diff-b8a6f00756b217a702a0bdb6cdab68c971f270293cfe64305c6e30ca97febaafL339-R340)

* Updated backend translation files (`django.po`) for Spanish (Latin America and Spain) to include the "My Learning" string, ensuring consistency between frontend and backend translations. [[1]](diffhunk://#diff-eed4225db3ef4aeaee86e85679f1cc3cbcb04f554acc2e56f9f960ef63b7a43aR27552-R27555) [[2]](diffhunk://#diff-1519e804243848284f64466402c31922286d2c25ec005e84a8f8db2542546d8fR26100-R26103)