### PR TITLE
fix: add missing translations Campus Agora

### DIFF
--- a/translations/edx-platform/conf/locale/es_419/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/es_419/LC_MESSAGES/django.po
@@ -27553,3 +27553,7 @@ msgstr "Soporte y Ayuda"
 #: lms/templates/header/header.html:140
 msgid "My Learning"
 msgstr "Mi aprendizaje"
+
+#: themes/metared/lms/templates/courseware/course_about.html:122
+msgid "Course Information"
+msgstr "Información del curso"

--- a/translations/edx-platform/conf/locale/es_ES/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/es_ES/LC_MESSAGES/django.po
@@ -27900,3 +27900,7 @@ msgstr "Ver más"
 #: themes/metared/lms/templates/courseware/course_about.html:368
 msgid "Related Courses"
 msgstr "Cursos relacionados"
+
+#: themes/metared/lms/templates/courseware/course_about.html:122
+msgid "Course Information"
+msgstr "Información del curso"

--- a/translations/edx-platform/conf/locale/pt_PT/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/pt_PT/LC_MESSAGES/django.po
@@ -27577,3 +27577,7 @@ msgstr "Ver mais"
 #: themes/metared/lms/templates/courseware/course_about.html:368
 msgid "Related Courses"
 msgstr "Cursos relacionados"
+
+#: themes/metared/lms/templates/courseware/course_about.html:122
+msgid "Course Information"
+msgstr "Informação do Curso"

--- a/translations/frontend-app-authn/src/i18n/messages/es_419.json
+++ b/translations/frontend-app-authn/src/i18n/messages/es_419.json
@@ -185,5 +185,7 @@
   "soa_footer_main.accessibility": "Accesibilidad",
   "soa_footer_main.support": "Soporte y Ayuda",
   "soa_footer_main.allRightReserved": "Todos los derechos reservados.",
-  "header.menu.soa.myLearning.label": "Mi aprendizaje"
+  "header.menu.soa.myLearning.label": "Mi aprendizaje",
+  "registration.announcement.title": "Muy pronto podrás formarte con los mejores cursos.",
+  "registration.announcement.message": "El registro <b>se abrirá el {date, date, long}</b> y será totalmente gratuito."
 }

--- a/translations/frontend-app-authn/src/i18n/messages/es_ES.json
+++ b/translations/frontend-app-authn/src/i18n/messages/es_ES.json
@@ -168,7 +168,7 @@
   "reset.password.success.heading": "Restablecimiento de la contraseña completado.",
   "reset.password.success": "Tu contraseña ha sido restablecida. Inicia sesión con tu cuenta.",
   "rate.limit.error": "Se ha producido un error debido al número de solicitudes recibidas. Por favor, inténtalo de nuevo dentro de unos minutos.",
-  "start.learning": "Comienza tu aprendizaje",
+  "start.learning": "Empieza a aprender",
   "with.site.name": "con {siteName}",
   "your.career.turning.point": "El punto de inflexión de su carrera",
   "is.here": "es aquí.",

--- a/translations/frontend-app-authn/src/i18n/messages/es_ES.json
+++ b/translations/frontend-app-authn/src/i18n/messages/es_ES.json
@@ -188,5 +188,7 @@
   "register.page.terms.of.service": "He leído y acepto la {privacyPolicy}, {generalTermsOfUse} y {cookiePolicy}.",
   "registration.accept.all.label": "Aceptar todo:",
   "general.terms.of.use": "Condiciones generales de uso",
-  "cookie.policy": "Política de Cookies"
+  "cookie.policy": "Política de Cookies",
+  "registration.announcement.title": "Muy pronto podrás formarte con los mejores cursos.",
+  "registration.announcement.message": "El registro <b>se abrirá el {date, date, long}</b> y será totalmente gratuito."
 }

--- a/translations/frontend-app-authn/src/i18n/messages/pt_PT.json
+++ b/translations/frontend-app-authn/src/i18n/messages/pt_PT.json
@@ -188,5 +188,7 @@
   "register.page.terms.of.service": "Li e aceito a {privacyPolicy}, os {generalTermsOfUse} e a {cookiePolicy}.",
   "registration.accept.all.label": "Aceitar tudo:",
   "general.terms.of.use": "Termos Gerais de Utilização",
-  "cookie.policy": "Política de Cookies"
+  "cookie.policy": "Política de Cookies",
+   "registration.announcement.title": "Muito em breve, poderá aprender com os melhores cursos.",
+   "registration.announcement.message": "O registo <b>abrirá em {date, date, long}</b> e será completamente gratuito."
 }


### PR DESCRIPTION
Adds missing translations for the **Campus Agora** platform across `es_ES`, `es_419`, and `pt_PT` locales.

### Changes

**`edx-platform` (Mako/Django templates)**
- Added translation for `"Course Information"` used in the custom metared theme's `course_about.html` page (`django.po` for `es_ES`, `es_419`, and `pt_PT`).
- Change string from "Comienza tu aprendizaje" to "Empieza a aprender"

**`frontend-app-authn` (MFE)**
- Fixed missing translations in the Authn MFE for `es_ES`, `es_419`, and `pt_PT`.

### Context

The `"Course Information"` string appears in the course about page sidebar (`themes/metared/lms/templates/courseware/course_about.html:122`). It is a custom theme string not present in the upstream `openedx/openedx-translations` catalog, so it must be provided here.